### PR TITLE
Add a SHP download link to the RNDT metadata

### DIFF
--- a/g3w-admin/qdjango/utils/catalog_provider.py
+++ b/g3w-admin/qdjango/utils/catalog_provider.py
@@ -51,9 +51,11 @@ def catalog_provider(groups=[]):
 
     def _get_url(qgs_project):
 
-        url = '{}://{}/ows/{}/{}/{}/'.format(
+        port = getattr(settings, 'CATALOG_PORT', '80')
+        url = '{}://{}{}/ows/{}/{}/{}/'.format(
             getattr(settings, 'CATALOG_URL_SCHEME', 'http'),
             getattr(settings, 'CATALOG_HOST', 'localhost'),
+            ('' if port == '80' else ':' + port),
             qgs_project.group.slug,
             'qdjango',
             qgs_project.pk

--- a/g3w-admin/qdjango/vector.py
+++ b/g3w-admin/qdjango/vector.py
@@ -63,11 +63,28 @@ class QGISLayerVectorViewMixin(object):
 
     def get_layer_by_params(self, params):
 
-        layer_id = params['layer_name']
+
+        """ !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+        #     #    #    ######  #     # ### #     #  #####
+        #  #  #   # #   #     # ##    #  #  ##    # #     #
+        #  #  #  #   #  #     # # #   #  #  # #   # #
+        #  #  # #     # ######  #  #  #  #  #  #  # #  ####
+        #  #  # ####### #   #   #   # #  #  #   # # #     #
+        #  #  # #     # #    #  #    ##  #  #    ## #     #
+         ## ##  #     # #     # #     # ### #     #  #####
+
+        gets a layer_name in params but then it queries for the
+        qgs_layer_id
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! """
+
+
+        qgs_layer_id = params['layer_name']
         project_id = params['project_id']
 
         # get layer object from qdjango model layer
-        return self._layer_model.objects.get(project_id=project_id, qgs_layer_id=layer_id)
+        return self._layer_model.objects.get(project_id=project_id, qgs_layer_id=qgs_layer_id)
 
     def get_geoserializer_kwargs(self):
 


### PR DESCRIPTION
requires the catalog patch that actually generates the download links XML https://bitbucket.org/gis3w/g3w-admin-catalog/pull-requests/7/adds-the-download-link-for-vector-layers/diff