### PR TITLE
Fix value relation formatters

### DIFF
--- a/g3w-admin/editing/api/base/views.py
+++ b/g3w-admin/editing/api/base/views.py
@@ -157,6 +157,9 @@ class BaseEditingVectorOnModelApiView(BaseVectorOnModelApiView):
                 for geojson_feature in post_layer_data[mode_editing]:
                     data_extra_fields = {'feature': geojson_feature}
 
+                    # Clear any old error
+                    qgis_layer.dataProvider().clearErrors()
+
                     # add media data
                     self.add_media_property(geojson_feature, metadata_layer)
 
@@ -310,6 +313,8 @@ class BaseEditingVectorOnModelApiView(BaseVectorOnModelApiView):
 
                 # FIXME: pre_delete_maplayer
                 # pre_delete_maplayer.send(metadata_layer.serializer, layer=metadata_layer.layer_id, # data=serializer.data, user=self.request.user)
+
+                qgis_layer.dataProvider().clearErrors()
 
                 if has_transactions:
                     if not qgis_layer.deleteFeatures([feature_id]) or qgis_layer.dataProvider().errors():

--- a/g3w-admin/editing/tests/test_api_transaction_group.py
+++ b/g3w-admin/editing/tests/test_api_transaction_group.py
@@ -236,15 +236,15 @@ class TransactionGroupTest(TestCase):
 
         jresult = json.loads(response.content)
         self.assertTrue(jresult['result'])
-        self.assertEqual(jresult['response']['new'][0]['id'], 5)
+        self.assertEqual(jresult['response']['new'][0]['id'], 6)
         self.assertEqual(jresult['response']['new'][0]['properties']['name'], "name 1")
         self.assertEqual(jresult['response']['new'][0]['properties']['value'], 12345)
 
         # Retrieve the feature and check
         qgis_layer = self.test.qgis_layer
-        feature = qgis_layer.getFeature(5)
+        feature = qgis_layer.getFeature(6)
         self.assertEqual(feature.attributes(), [
-                         5, 'name 1', 12345, QDate(2021, 1, 2), True, 2])
+                         6, 'name 1', 12345, QDate(2021, 1, 2), True, 2])
 
         # Test error conditions:
         # 1: NULL pol_id
@@ -319,7 +319,7 @@ class TransactionGroupTest(TestCase):
         self.assertFalse(jresult['result'])
 
     def test_update_feature_simple(self):
-        """Test adding a test feature to an existing polygon"""
+        """Test updating a test feature to an existing polygon"""
 
         client = APIClient()
         self.assertTrue(client.login(

--- a/g3w-admin/editing/tests/test_api_transaction_group.py
+++ b/g3w-admin/editing/tests/test_api_transaction_group.py
@@ -26,7 +26,6 @@ from editing.models import *
 from django.urls import reverse
 from rest_framework.test import APIClient
 from usersmanage.tests.utils import *
-from qdjango.apps import QGS_PROJECTS_CACHE
 
 # Makes a copy of test project and data into a temporary directory
 
@@ -83,10 +82,6 @@ class TransactionGroupTest(TestCase):
     def reset_db_data(cls):
         """Restore test database from backup
         It is necessary at the end of every single test where data test are changing"""
-
-        # Delete any open project
-        for p in list(QGS_PROJECTS_CACHE.keys()):
-            del (QGS_PROJECTS_CACHE[p])
 
         shutil.copy(QGS_DB_BACKUP, QGS_DB)
 

--- a/g3w-admin/qdjango/receivers.py
+++ b/g3w-admin/qdjango/receivers.py
@@ -7,9 +7,9 @@ from core.signals import perform_client_search, post_delete_project
 from OWS.utils.data import GetFeatureInfoResponse
 from .models import Project, Layer, Widget
 from .ows import OWSRequestHandler
-from .apps import QGS_PROJECTS_CACHE
 import os
 import logging
+from qgis.server import QgsConfigCache
 
 logger = logging.getLogger('django.request')
 
@@ -29,10 +29,8 @@ def delete_project_file(sender, **kwargs):
     if 'qdjango' in settings.CACHES:
         caches['qdjango'].delete(settings.QDJANGO_PRJ_CACHE_KEY.format(instance.pk))
 
-    try:
-        del QGS_PROJECTS_CACHE[instance.qgis_file.path]
-    except KeyError:
-        pass
+    QgsConfigCache.instance().removeEntry(instance.qgis_file.path)
+
 
 @receiver(post_save, sender=Project)
 def delete_cache_project_settings(sender, **kwargs):
@@ -43,11 +41,8 @@ def delete_cache_project_settings(sender, **kwargs):
     if 'qdjango' in settings.CACHES:
         caches['qdjango'].delete(settings.QDJANGO_PRJ_CACHE_KEY.format(kwargs['instance'].pk))
 
-    try:
-        instance = kwargs['instance']
-        del QGS_PROJECTS_CACHE[instance.qgis_file.path]
-    except KeyError:
-        pass
+    instance = kwargs['instance']
+    QgsConfigCache.instance().removeEntry(instance.qgis_file.path)
 
 @receiver(post_save, sender=Layer)
 def update_widget(sender, **kwargs):

--- a/g3w-admin/qdjango/tests/data/g3wsuite_project_test_qgis310.qgs
+++ b/g3w-admin/qdjango/tests/data/g3wsuite_project_test_qgis310.qgs
@@ -462,10 +462,10 @@
         <fieldstyles/>
       </conditionalstyles>
       <storedexpressions/>
-      <editform tolerant="1">"./data</editform>
+      <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
-      <editforminitfilepath>"./data</editforminitfilepath>
+      <editforminitfilepath></editforminitfilepath>
       <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 I form QGIS possono avere una funzione Python che può essere chiamata quando un form viene aperto.
@@ -901,10 +901,10 @@ def my_form_open(dialog, layer, feature):
         <fieldstyles/>
       </conditionalstyles>
       <storedexpressions/>
-      <editform tolerant="1">"./data</editform>
+      <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
-      <editforminitfilepath>"./data</editforminitfilepath>
+      <editforminitfilepath></editforminitfilepath>
       <editforminitcode><![CDATA[]]></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
@@ -1145,10 +1145,10 @@ def my_form_open(dialog, layer, feature):
         <fieldstyles/>
       </conditionalstyles>
       <storedexpressions/>
-      <editform tolerant="1">"./data</editform>
+      <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
-      <editforminitfilepath>"./data</editforminitfilepath>
+      <editforminitfilepath></editforminitfilepath>
       <editforminitcode><![CDATA[]]></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>

--- a/g3w-admin/qdjango/tests/test_accesscontrol.py
+++ b/g3w-admin/qdjango/tests/test_accesscontrol.py
@@ -14,7 +14,7 @@ import os
 from django.test import Client
 from django.urls import reverse
 from django.conf import settings
-from qdjango.apps import QGS_SERVER, QGS_PROJECTS_CACHE, get_qgs_project
+from qdjango.apps import QGS_SERVER, get_qgs_project
 from qdjango.models import Project
 from .base import QdjangoTestBase
 

--- a/g3w-admin/qdjango/tests/test_constraints.py
+++ b/g3w-admin/qdjango/tests/test_constraints.py
@@ -24,7 +24,7 @@ from django.urls import reverse
 from qgis.core import QgsVectorLayer, QgsFeatureRequest, QgsExpression, Qgis
 from qgis.PyQt.QtCore import QTemporaryDir
 
-from qdjango.apps import QGS_PROJECTS_CACHE, QGS_SERVER, get_qgs_project
+from qdjango.apps import QGS_SERVER, get_qgs_project
 from qdjango.models import (
     ConstraintSubsetStringRule,
     ConstraintExpressionRule,

--- a/g3w-admin/qdjango/tests/test_ows.py
+++ b/g3w-admin/qdjango/tests/test_ows.py
@@ -18,7 +18,7 @@ from django.urls import reverse
 from qgis.core import QgsProject
 from core.models import G3WSpatialRefSys
 from core.models import Group as CoreGroup
-from qdjango.apps import QGS_SERVER, QGS_PROJECTS_CACHE, get_qgs_project
+from qdjango.apps import QGS_SERVER, get_qgs_project
 from qdjango.models import Project
 from .base import QdjangoTestBase, CURRENT_PATH, TEST_BASE_PATH, QGS310_WIDGET_FILE, QgisProject
 import json
@@ -62,7 +62,8 @@ class OwsTest(QdjangoTestBase):
 
         qgs_project = get_qgs_project(self.qdjango_project.qgis_file.path)
         self.assertTrue(isinstance(qgs_project, QgsProject))
-
+        qgs_project = self.qdjango_project.qgis_project
+        self.assertTrue(isinstance(qgs_project, QgsProject))
 
     def test_get(self):
         """Test get request"""
@@ -80,8 +81,6 @@ class OwsTest(QdjangoTestBase):
 
         self.assertTrue(b'<Name>bluemarble</Name>' in response.content)
 
-
-    @skip
     def test_get_getfeatureinfo(self):
         """Test GetFeatureInfo for QGIS widget"""
 
@@ -124,16 +123,4 @@ class OwsTest(QdjangoTestBase):
         self.assertEqual(features[0]['properties']['name'], 'olive')
         self.assertEqual(features[0]['properties']['type'], 'TYPE B')
 
-    def test_save_project(self):
-        """Test that when a project is saved it is also removed from the cache"""
-
-        file_path = self.qdjango_project.qgis_file.path
-        qgs_project = get_qgs_project(file_path)
-        self.assertTrue(isinstance(qgs_project, QgsProject))
-        self.assertTrue(file_path in QGS_PROJECTS_CACHE)
-        self.qdjango_project.save()
-        self.assertFalse(file_path in QGS_PROJECTS_CACHE)
-        # Re-cache
-        get_qgs_project(file_path)
-        self.assertTrue(file_path in QGS_PROJECTS_CACHE)
 


### PR DESCRIPTION
Well, fix ALL formatters, because of the way they resolve layers
from the QgsProject::instance() which was not handled by the
naive cache we was using, by switching to QgsConfigCache and
disabling bad layers with the new QGIS_SERVER_IGNORE_BAD_LAYERS
config option we fix the issue while we retain the caching
functionality for project and layers.