### PR TITLE
Initial vector tiles support

### DIFF
--- a/g3w-admin/qdjango/models/projects.py
+++ b/g3w-admin/qdjango/models/projects.py
@@ -317,7 +317,8 @@ class Layer(G3WACLModelMixins, models.Model):
         ('arcgisfeatureserver', _('ArcGisFeatureServer')),
         ('mssql', _('MSSQL')),
         ('virtual', _('VirtualLayer')),
-        ('oracle', _('Oracle'))
+        ('oracle', _('Oracle')),
+        ('vector-tile', _('Vector Tile'))
     )
 
     # General info

--- a/g3w-admin/qdjango/utils/validators.py
+++ b/g3w-admin/qdjango/utils/validators.py
@@ -310,7 +310,7 @@ class DatasourceExists(QgisProjectLayerValidator):
             Layer.TYPES.ogr,
             Layer.TYPES.raster] and not isXML(self.qgisProjectLayer.datasource):
 
-            # tray PostGis raster layer
+            # try PostGis raster layer
             if self.qgisProjectLayer.datasource.startswith("PG:"):
 
                 # try to open postgis raster with gdal


### PR DESCRIPTION
I suppose we miss something in the client.

Keep in mind that unlike **all** other QGIS sources, vector tiles have no data provider.