### PR TITLE
Add QGIS functions support and set tree visibility from LAYERS in ows.py

### DIFF
--- a/g3w-admin/qdjango/apps.py
+++ b/g3w-admin/qdjango/apps.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import glob
+import importlib
 
 from core.utils.general import getAuthPermissionContentType
 from django.apps import AppConfig, apps
@@ -261,3 +263,12 @@ class QdjangoConfig(AppConfig):
         # Load all QGIS server services plugins, apps can load additional services
         # by registering them directly to QGS_SERVER
         from . import server_filters, server_services
+
+        # Load custom QGIS functions from qdjango/qgis_functions directory
+        functions_folder = os.path.join(
+            os.path.dirname(__file__), 'qgis_functions')
+
+        for f in glob.glob(functions_folder + '/*.py'):
+            if '__init__.py' not in f:
+                basename = os.path.basename(f)[:-3]
+                importlib.import_module('qdjango.qgis_functions.' + basename)

--- a/g3w-admin/qdjango/qgis_functions/get_first_checked_layer_from_group.py
+++ b/g3w-admin/qdjango/qgis_functions/get_first_checked_layer_from_group.py
@@ -1,0 +1,23 @@
+from qgis.core import *
+from qgis.gui import *
+
+import logging
+
+logger = logging.getLogger('qdjango')
+
+@qgsfunction(args='auto', group='Custom', referenced_columns=[])
+def get_first_checked_layer_from_group(legend_group, feature, parent):
+    """
+    Returns the id of the first visible (checked) layer from a given legend group name
+    """
+    try:
+        p = QgsProject.instance()
+        r = p.layerTreeRoot()
+        r.findGroup(legend_group)
+        g = r.findGroup(legend_group)
+        logger.debug('QGIS function get_first_checked_layer_from_group returned {}'.format(g.checkedLayers()[0].name(
+        )))
+        return g.checkedLayers()[0].id()
+    except:
+        pass
+    return None

--- a/g3w-admin/qdjango/qgis_functions/get_first_checked_layer_from_group.py
+++ b/g3w-admin/qdjango/qgis_functions/get_first_checked_layer_from_group.py
@@ -5,6 +5,7 @@ import logging
 
 logger = logging.getLogger('qdjango')
 
+
 @qgsfunction(args='auto', group='Custom', referenced_columns=[])
 def get_first_checked_layer_from_group(legend_group, feature, parent):
     """
@@ -13,7 +14,6 @@ def get_first_checked_layer_from_group(legend_group, feature, parent):
     try:
         p = QgsProject.instance()
         r = p.layerTreeRoot()
-        r.findGroup(legend_group)
         g = r.findGroup(legend_group)
         logger.debug('QGIS function get_first_checked_layer_from_group returned {}'.format(g.checkedLayers()[0].name(
         )))


### PR DESCRIPTION
Functions are stored in separate file in qdjango/qgis_functions
and loaded in app.py startup.

A test function is provided: get_first_checked_layer_from_group.

The project's legend is manipulated to make sure that the requested
LAYERS are checked (and their parents in the tree as well).

This makes it possible to get the visible (checked) layer from a group in a print layout.

![mutex_visible_layers](https://user-images.githubusercontent.com/142164/151332362-3dfedaae-d178-4fe9-b3ff-dc279826b809.gif)
