### PR TITLE
add translation files import and export commands for manage.py

### DIFF
--- a/g3w-admin/base/management/commands/export_language_files.py
+++ b/g3w-admin/base/management/commands/export_language_files.py
@@ -1,0 +1,39 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+import os
+import shutil
+
+class Command(BaseCommand):
+    help = 'Exports all found language files using the path as file naming for a future re-import.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('-p', '--outpath', type=str, help='The path to the folder to which to export the files to.')
+
+    def handle(self, *args, **options):
+    
+        output_folder_path = options['outpath']
+        if not output_folder_path:
+            self.stderr.write("The ouput folder path is mandatory!")
+            return
+
+        base_folder = str(settings.BASE_DIR / 'g3w-admin/g3w-admin')
+        
+        print(f"Looking for tanslation files (*.po) inside: {base_folder}")
+
+        for (dir_path, dir_names, file_names) in os.walk(base_folder):
+            for file_name in file_names:
+                if file_name.endswith(".po"):
+                    rel_path = dir_path.split("G3WSUITE/g3w-admin/g3w-admin/")[1].replace('/','_')
+
+                    new_filename = rel_path + "_" + file_name
+
+                    from_path = os.path.join(dir_path, file_name)
+                    to_path = os.path.join(output_folder_path, new_filename)
+
+                    print(f"Copying {from_path}")
+                    print(f"   ---> {to_path}")
+                    shutil.copyfile(from_path, to_path)
+
+        print("Done.")
+        
+        

--- a/g3w-admin/base/management/commands/export_language_files.py
+++ b/g3w-admin/base/management/commands/export_language_files.py
@@ -10,7 +10,8 @@ class Command(BaseCommand):
         parser.add_argument('-p', '--outpath', type=str, help='The path to the folder to which to export the files to.')
 
     def handle(self, *args, **options):
-    
+        separator = "___"
+
         output_folder_path = options['outpath']
         if not output_folder_path:
             self.stderr.write("The ouput folder path is mandatory!")
@@ -23,9 +24,9 @@ class Command(BaseCommand):
         for (dir_path, dir_names, file_names) in os.walk(base_folder):
             for file_name in file_names:
                 if file_name.endswith(".po"):
-                    rel_path = dir_path.split("G3WSUITE/g3w-admin/g3w-admin/")[1].replace('/','_')
+                    rel_path = dir_path.split("G3WSUITE/g3w-admin/g3w-admin/")[1].replace('/', separator)
 
-                    new_filename = rel_path + "_" + file_name
+                    new_filename = rel_path + separator + file_name
 
                     from_path = os.path.join(dir_path, file_name)
                     to_path = os.path.join(output_folder_path, new_filename)

--- a/g3w-admin/base/management/commands/import_language_files.py
+++ b/g3w-admin/base/management/commands/import_language_files.py
@@ -1,0 +1,36 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+import os
+import shutil
+
+class Command(BaseCommand):
+    help = "Import language files previously exported through the 'export_language_files' command from a folder."
+
+    def add_arguments(self, parser):
+        parser.add_argument('-p', '--inpath', type=str, help='The path to the folder from which to import the files.')
+
+    def handle(self, *args, **options):
+        separator = "___"
+
+        input_folder_path = options['inpath']
+        if not input_folder_path:
+            self.stderr.write("The input folder path is mandatory!")
+            return
+
+        base_folder = str(settings.BASE_DIR / 'g3w-admin/g3w-admin')
+        
+        print(f"Looking for tanslation files (*.po) inside: {input_folder_path}")
+
+        for file in os.listdir(input_folder_path):
+            if file.endswith(".po"):
+                rel_file_path = file.replace(separator, "/")
+
+                from_path = os.path.join(input_folder_path, file)
+                to_path = os.path.join(base_folder, rel_file_path)
+                print(f"Copying {from_path}")
+                print(f"   ---> {to_path}")
+                shutil.copyfile(from_path, to_path)
+
+        print("Done.")
+        
+        


### PR DESCRIPTION
This PR adds two manage.py commands:

1) export_language_files

This looks for all the translation files in the project and copies them into an existing folder, using their folder tree to name them. That way it is possible to import them back in the right place.

Example usage: ./manage.py export_language_files -p /home/hydrologis/TMP/translationfiles

2) import_language_files

This takes *.po files from a folder and copies them back into the right place in the project structure.



