### PR TITLE
Fix embedded alias

### DIFF
--- a/g3w-admin/qdjango/utils/data.py
+++ b/g3w-admin/qdjango/utils/data.py
@@ -1424,12 +1424,13 @@ class QgisProject(XmlData):
                             self.instance.qgis_file.path, Layer.TYPES.ogr)
                         changed = True
 
-                    # Updates editor_form_structure
+                    # Updates the layer
                     try:
-                        structure = self.instance.layer_set.get(qgs_layer_id=layer_id).editor_form_structure
-                        if structure != embedded_layer.editor_form_structure:
-                            embedded_layer.editor_form_structure = structure
-                            embedded_layer.save()
+                        layer_instance = self.instance.layer_set.get(qgs_layer_id=layer_id)
+                        embedded_layer.editor_form_structure = layer_instance.editor_form_structure
+                        embedded_layer.extent = layer_instance.extent
+                        embedded_layer.database_columns = layer_instance.database_columns
+                        embedded_layer.save()
                     except Layer.DoesNotExist:
                         # Layer is gone
                         pass


### PR DESCRIPTION
Now the following fields are always updated on the parent upload:

- editor_form_structure  (it was already before this patch)
- extent  (new)
- database_columns (new)

I'm not sure if any other fields from the parent layers set should be updated as well, in case they are needed it's just a matter of adding them here:

https://github.com/g3w-suite/g3w-admin/compare/bugfix-embedded-alias?expand=1#diff-5c82032518c30a2f5dc1d23dcfffe0c737469784d9eb73b8cb86180f1e5df05aR1431