### PR TITLE
Update requirements for compatiblility with Django==3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2.28
-django-autoslug==1.9.6
+django-autoslug==1.9.8
 django-formtools==2.2
 django-crispy-forms==1.8.1
 django-extensions==2.2.5
@@ -14,7 +14,8 @@ django-debug-panel==0.8.3
 django-mptt==0.10.0
 django-ordered-model==3.3.0
 django-ajax-selects==1.8.0
-django-modeltranslation==0.14.4
+django-modeltranslation==0.17.7
+django-utils-six==2.0
 django-filter
 pathlib
 lxml


### PR DESCRIPTION
Update python library to be compatible with Django3.2 (and are still compatible with Django==2.2.28)