### PR TITLE
Add `.github/release.yml` (github release notes automation)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,40 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: 🚀 New Features
+      labels:
+        - feature
+    - title: 🐞 Bug fixed
+      labels:
+        - bug
+    - title: ✨ Improvements
+      labels:
+        - ux
+    - title: 📝 Documentation
+      labels:
+        - docs
+    - title: 👨‍🚀 Translations
+      labels:
+        - i18n
+    - title: 🐙 Github
+      labels:
+        - github
+    - title: 🧪 Tests
+      labels:
+        - tests
+    - title: 🛠️ Config
+      labels:
+        - config
+    - title: ♻️ API changes
+      labels:
+        - refactoring
+    - title: ⚠️ Breaking changes
+      labels:
+        - breaking
+    - title: ⚓ Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
Add the aforementioned file as per https://github.com/g3w-suite/g3w-client/pull/120 and https://github.com/g3w-suite/g3w-client/pull/194

---

**TODO (before merge):** 

This is still a work in progress, as it also needs to implement some sort of [git tag](https://github.com/g3w-suite/g3w-client/issues/112) versioning to make it work properly, also need to check [here](https://github.com/g3w-suite/g3w-admin/labels) more carefully the naming and colors of the labels to make it more consistent with those indicated in the `release.yml` file and with [g3w-client](https://github.com/g3w-suite/g3w-admin/labels) repository, for instance:

- [x] rename the `enhancement` label into `feature`
- [x] add the `breaking`, `config`, `i18n`, `tests`, `ux` labels

**Old labels to check (and possibly remove) as they are not considered during the changelog generation**

- [x] [`add_to_changelog`](https://github.com/g3w-suite/g3w-admin/issues?q=label%3Aadd_to_changelog+is%3Aclosed) (consider using `ignore-for-release` label instead)
- [x] [`cannot reproduce`](https://github.com/g3w-suite/g3w-admin/issues?q=label%3A%22cannot+reproduce%22+is%3Aclosed) (consider using `invalid` label instead)
- [x] [`deploy`](https://github.com/g3w-suite/g3w-admin/issues?q=label%3Adeploy+is%3Aclosed)
- [x] [`editing mode`](https://github.com/g3w-suite/g3w-admin/issues?q=label%3A%22editing+mode%22+is%3Aclosed)
- [x] [`javascript`](https://github.com/g3w-suite/g3w-admin/issues?q=label%3Ajavascript+is%3Aclosed) (consider using `dependencies` label instead)
- [x] [`python`](https://github.com/g3w-suite/g3w-admin/issues?q=label%3Apython+is%3Aclosed) (consider using `dependencies` label instead)
- [x] [`qgis_3.16`](https://github.com/g3w-suite/g3w-admin/issues?q=label%3Aqgis_3.16+is%3Aclosed) (consider using **github milestones** instead)
- [x] [`qgis-api`](https://github.com/g3w-suite/g3w-admin/issues?q=label%3Aqgis-api+is%3Aclosed)
- [x] [`todo`](https://github.com/g3w-suite/g3w-admin/issues?q=label%3Atodo+is%3Aclosed) (consider using **github milestones** instead)

---

### G3W-ADMIN labels (v3.5)

![photo](https://user-images.githubusercontent.com/9614886/200506232-25a5c351-909f-4130-a59c-05df53366328.png)

### G3W-CLIENT labels (v3.7.0.alpha.1)

![immagine](https://user-images.githubusercontent.com/9614886/200508104-12f6f451-d575-4509-ad36-9b1388e61ea2.png)

