### PR TITLE
Apply same code style for `urls.py` and `apiurls.py` routes

### DIFF
--- a/g3w-admin/OWS/urls.py
+++ b/g3w-admin/OWS/urls.py
@@ -5,7 +5,15 @@ app_name = 'OWS'
 
 urlpatterns = [
     # url working for qgis wms client
-    re_path(r'^ows/(?P<map_name_alias>[-_\w\d]+)/&?$', ows_alias_view, name='ows-alias'),
-    re_path(r'^ows/(?P<group_slug>[-_\w\d]+)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[-_\w\d]+)/&?$',
-            OWSView.as_view(), name='ows'),
+    re_path(
+        r'^ows/(?P<map_name_alias>[-_\w\d]+)/&?$',
+        ows_alias_view,
+        name='ows-alias'
+    ),
+
+    re_path(
+        r'^ows/(?P<group_slug>[-_\w\d]+)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[-_\w\d]+)/&?$',
+        OWSView.as_view(),
+        name='ows'
+    ),
 ]

--- a/g3w-admin/base/urls.py
+++ b/g3w-admin/base/urls.py
@@ -27,41 +27,89 @@ G3W_SITETREE_I18N_ALIAS = ['core', 'acl']
 #}
 
 extra_context_login_page = {
-            'adminlte_skin': 'login-page',
-            'adminlte_layout_option': None
-        }
+    'adminlte_skin': 'login-page',
+    'adminlte_layout_option': None
+}
 
 urlpatterns = [
-    path('i18n/', include('django.conf.urls.i18n')),
-    path('django-admin/', admin.site.urls),
-    path('{}'.format(BASE_ADMIN_URLPATH), include('core.urls')),
-    path('{}'.format(BASE_ADMIN_URLPATH), include('usersmanage.urls')),
-    path('upload/', include('django_file_form.urls')),
-    path('', include('client.urls')),
-    path('login/', auth.views.LoginView.as_view(template_name='login.html', extra_context=extra_context_login_page),
-        name='login'),
-    path('logout/', auth.views.LogoutView.as_view(
-        next_page=settings.LOGOUT_NEXT_PAGE + '{}'.format(BASE_ADMIN_URLPATH)), name='logout'),
-    path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
-    path('ajax_select/', include(ajax_select_urls))
+    path(
+        'i18n/',
+        include('django.conf.urls.i18n')
+    ),
+    path(
+        'django-admin/',
+        admin.site.urls
+    ),
+    path(
+        '{}'.format(BASE_ADMIN_URLPATH),
+        include('core.urls')
+    ),
+    path(
+        '{}'.format(BASE_ADMIN_URLPATH),
+        include('usersmanage.urls')
+    ),
+    path(
+        'upload/',
+        include('django_file_form.urls')
+    ),
+    path(
+        '',
+        include('client.urls')
+    ),
+    path(
+        'login/',
+        auth.views.LoginView.as_view(template_name='login.html', extra_context=extra_context_login_page),
+        name='login'
+    ),
+    path(
+        'logout/',
+        auth.views.LogoutView.as_view(next_page=settings.LOGOUT_NEXT_PAGE + '{}'.format(BASE_ADMIN_URLPATH)),
+        name='logout'
+    ),
+    path(
+        'jsi18n/',
+        JavaScriptCatalog.as_view(),
+        name='javascript-catalog'
+    ),
+    path(
+        'ajax_select/',
+        include(ajax_select_urls)
+    )
 ]
 
 # Add path/url for user password rest by email
 if settings.RESET_USER_PASSWORD:
     urlpatterns += [
-        path('password_change/', auth.views.PasswordChangeView.as_view(extra_context=extra_context_login_page),
-             name='password_change'),
-        path('password_change/done/', auth.views.PasswordChangeDoneView.as_view(extra_context=extra_context_login_page),
-             name='password_change_done'),
-        path('password_reset/', auth.views.PasswordResetView.as_view(extra_context=extra_context_login_page),
-             name='password_reset'),
-        path('password_reset/done/', auth.views.PasswordResetDoneView.as_view(extra_context=extra_context_login_page),
-             name='password_reset_done'),
-        path('reset/<uidb64>/<token>/',
-             auth.views.PasswordResetConfirmView.as_view(extra_context=extra_context_login_page),
-             name='password_reset_confirm'),
-        path('reset/done/', auth.views.PasswordResetCompleteView.as_view(extra_context=extra_context_login_page),
-             name='password_reset_complete'),
+        path(
+            'password_change/',
+            auth.views.PasswordChangeView.as_view(extra_context=extra_context_login_page),
+            name='password_change'
+        ),
+        path(
+            'password_change/done/',
+            auth.views.PasswordChangeDoneView.as_view(extra_context=extra_context_login_page),
+            name='password_change_done'
+        ),
+        path(
+            'password_reset/',
+            auth.views.PasswordResetView.as_view(extra_context=extra_context_login_page),
+            name='password_reset'
+        ),
+        path(
+            'password_reset/done/',
+            auth.views.PasswordResetDoneView.as_view(extra_context=extra_context_login_page),
+            name='password_reset_done'
+        ),
+        path(
+            'reset/<uidb64>/<token>/',
+            auth.views.PasswordResetConfirmView.as_view(extra_context=extra_context_login_page),
+            name='password_reset_confirm'
+        ),
+        path(
+            'reset/done/',
+            auth.views.PasswordResetCompleteView.as_view(extra_context=extra_context_login_page),
+            name='password_reset_complete'
+        ),
     ]
 
 apiUrlpatterns = [
@@ -75,6 +123,7 @@ if BASE_ADMIN_URLPATH == 'admin/':
 #adding projects app
 #if BASE_ADMIN_URLPATH:
     #base = BASE_ADMIN_URLPATH[0:-1]
+
 for app in settings.G3WADMIN_PROJECT_APPS:
     urlpatterns.append(path('{}{}/'.format(BASE_ADMIN_URLPATH, app), include('{}.urls'.format(app))))
     try:

--- a/g3w-admin/client/apiurls.py
+++ b/g3w-admin/client/apiurls.py
@@ -1,15 +1,19 @@
 from django.urls import path
-from .api.views import \
-    GroupConfigApiView, \
-    ClientConfigApiView
+from .api.views import GroupConfigApiView, ClientConfigApiView
 
 urlpatterns = [
 
     # Main init client API rest initialization
     # ========================================
-    path('api/initconfig/<slug:group_slug>/<project_type>/<int:project_id>', GroupConfigApiView.as_view(),
-         name='group-map-config'),
+    path(
+        'api/initconfig/<slug:group_slug>/<project_type>/<int:project_id>',
+        GroupConfigApiView.as_view(),
+            name='group-map-config'
+    ),
 
-    path('api/config/<slug:group_slug>/<project_type>/<int:project_id>', ClientConfigApiView.as_view(),
-         name='group-project-map-config'),
+    path(
+        'api/config/<slug:group_slug>/<project_type>/<int:project_id>',
+        ClientConfigApiView.as_view(),
+         name='group-project-map-config'
+    ),
 ]

--- a/g3w-admin/client/urls.py
+++ b/g3w-admin/client/urls.py
@@ -7,17 +7,34 @@ USER_MEDIA_PREFIX = 'me'
 urlpatterns = [
 
     # g3w-client bootstrap
-    re_path(r'^map/(?P<map_name_alias>[-_\w\d]+)/$', client_map_alias_view,
-        name='group-project-map-alias'),
-    re_path(r'^map/(?P<group_slug>[-_\w\d]+)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/$', ClientView.as_view(),
-        name='group-project-map'),
-    re_path(r'^map/(?P<group_slug>[-_\w\d]+)/(?P<project_type>[-_\w\d]+)/(?P<project_slug>[-_\w\d]+)/$',
-        ClientView.as_view(), name='group-project-slug-map'),
+    re_path(
+        r'^map/(?P<map_name_alias>[-_\w\d]+)/$',
+        client_map_alias_view,
+        name='group-project-map-alias'
+    ),
+
+    re_path(
+        r'^map/(?P<group_slug>[-_\w\d]+)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/$',
+        ClientView.as_view(),
+        name='group-project-map'
+    ),
+
+    re_path(
+        r'^map/(?P<group_slug>[-_\w\d]+)/(?P<project_type>[-_\w\d]+)/(?P<project_slug>[-_\w\d]+)/$',
+        ClientView.as_view(),
+        name='group-project-slug-map'
+    ),
 
     # url for media reading upload
-    re_path(r'^{}/(?P<project_type>[-_\w\d]+)/(?P<layer_id>[0-9]+)/(?P<file_name>[\(\)-_. \w\d]+)'
+    re_path(
+        r'^{}/(?P<project_type>[-_\w\d]+)/(?P<layer_id>[0-9]+)/(?P<file_name>[\(\)-_. \w\d]+)'
         .format(USER_MEDIA_PREFIX),
-        user_media_view, name='user-media'),
+        user_media_view, name='user-media'
+    ),
 
-    path('credits/', credits, name='client-credits'),
+    path(
+        'credits/',
+        credits,
+        name='client-credits'
+    ),
 ]

--- a/g3w-admin/core/apiurls.py
+++ b/g3w-admin/core/apiurls.py
@@ -12,46 +12,79 @@ from .views import GroupSetOrderView, MacroGroupSetOrderView
 
 
 urlpatterns = [
-    re_path(r'^' + settings.VECTOR_URL[1:] + r'(?P<mode_call>data|config|shp|xls|gpkg|gpx|csv|filtertoken)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/'
+    re_path(
+        r'^' + settings.VECTOR_URL[1:] + r'(?P<mode_call>data|config|shp|xls|gpkg|gpx|csv|filtertoken)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/'
         r'(?P<layer_name>[-_\w\d]+)/$',
-        layer_vector_view, name='core-vector-api'),
+        layer_vector_view,
+        name='core-vector-api'
+    ),
 
     # with extention
-    re_path(r'^' + settings.VECTOR_URL[1:] + r'(?P<mode_call>shp|xls|gpx|csv|gpkg)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/'
+    re_path(
+        r'^' + settings.VECTOR_URL[1:] + r'(?P<mode_call>shp|xls|gpx|csv|gpkg)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/'
         r'(?P<layer_name>[-_\w\d]+).(?P<ext>zip|xls|gpx|csv|gpkg)$',
-        layer_vector_view, name='core-vector-api-ext'),
+        layer_vector_view,
+        name='core-vector-api-ext'
+    ),
 
-    re_path(r'^' + settings.VECTOR_URL[1:] + r'(?P<mode_call>widget)/(?P<widget_type>[-_\w\d]+)/data/'
+    re_path(
+        r'^' + settings.VECTOR_URL[1:] + r'(?P<mode_call>widget)/(?P<widget_type>[-_\w\d]+)/data/'
         r'(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/'
         r'(?P<layer_name>[-_\w\d]+)/$',
-        layer_vector_view, name='core-vector-api-widget'),
+        layer_vector_view,
+        name='core-vector-api-widget'
+    ),
 
     # Changing order
-    path('jx/groups/<int:group_id>/setorder/', login_required(GroupSetOrderView.as_view()),
-         name='group-set-order'),
+    path(
+        'jx/groups/<int:group_id>/setorder/',
+        login_required(GroupSetOrderView.as_view()),
+        name='group-set-order'
+    ),
 
-    path('jx/macrogroups/<int:group_id>/setorder/', login_required(MacroGroupSetOrderView.as_view()),
-         name='macrogroup-set-order'),
+    path(
+        'jx/macrogroups/<int:group_id>/setorder/',
+        login_required(MacroGroupSetOrderView.as_view()),
+        name='macrogroup-set-order'
+    ),
 
-    path('api/deploy/info/', G3WSUITEInfoAPIView.as_view(), name='deploy-info-api'),
+    path(
+        'api/deploy/info/',
+        G3WSUITEInfoAPIView.as_view(),
+        name='deploy-info-api'
+    ),
 
     # POST only method to return QGIS Expressions evaluated in Project an optional Layer/Form context
     # (passing form_data and qgs_layer_id in the post body)
-    path('api/expression_eval/<int:project_id>/', login_required(QgsExpressionLayerContextEvalView.as_view()),
-         name='layer-expression-eval'),
+    path(
+        'api/expression_eval/<int:project_id>/',
+        login_required(QgsExpressionLayerContextEvalView.as_view()),
+        name='layer-expression-eval'
+    ),
 
     # General proxy view for Client external calls, i.e. for COORS.
     # =============================================================
-    path('interface/proxy/', InterfaceProxy.as_view(), name="interface-proxy"),
+    path(
+        'interface/proxy/',
+        InterfaceProxy.as_view(),
+        name="interface-proxy"
+    ),
 
     # Interface API to get informations, layer, styles to a ows services
     # ==================================================================
-    path('interface/ows/', InterfaceOws.as_view(), name="interface-ows"),
+    path(
+        'interface/ows/',
+        InterfaceOws.as_view(),
+        name="interface-ows"
+    ),
 
     # For raster data
     # ---------------
-    re_path(r'^' + settings.RASTER_URL[1:] + r'(?P<mode_call>geotiff)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/'
+    re_path(
+        r'^' + settings.RASTER_URL[1:] + r'(?P<mode_call>geotiff)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/'
         r'(?P<layer_name>[-_\w\d]+)/$',
-        layer_raster_view, name='core-raster-api'),
+        layer_raster_view,
+        name='core-raster-api'
+    ),
 
 ]

--- a/g3w-admin/core/urls.py
+++ b/g3w-admin/core/urls.py
@@ -13,37 +13,103 @@ def protected_serve(request, path, document_root=None, show_indexes=False):
 
 
 urlpatterns = [
-    path('', login_required(DashboardView.as_view()), name='home'),
+    path(
+        '',
+        login_required(DashboardView.as_view()),
+        name='home'
+    ),
 
     # macrogroups urls
-    path('macrogroups/', login_required(MacroGroupListView.as_view()), name='macrogroup-list'),
-    path('macrogroups/add/', login_required(MacroGroupCreateView.as_view()), name='macrogroup-add'),
-    path('macrogroups/update/<slug:slug>/', login_required(MacroGroupUpdateView.as_view()),
-        name='macrogroup-update'),
-    path('macrogroups/delete/<slug:slug>/', login_required(MacroGroupDeleteView.as_view()),
-        name='macrogroup-delete'),
-    path('macrogroups/<slug:slug>/', login_required(MacroGroupDetailView.as_view()),
-        name='macrogroup-detail'),
+    path(
+        'macrogroups/',
+        login_required(MacroGroupListView.as_view()),
+        name='macrogroup-list'
+    ),
+
+    path(
+        'macrogroups/add/',
+        login_required(MacroGroupCreateView.as_view()),
+        name='macrogroup-add'
+    ),
+
+    path(
+        'macrogroups/update/<slug:slug>/',
+        login_required(MacroGroupUpdateView.as_view()),
+        name='macrogroup-update'
+    ),
+
+    path(
+        'macrogroups/delete/<slug:slug>/',
+        login_required(MacroGroupDeleteView.as_view()),
+        name='macrogroup-delete'
+    ),
+
+    path(
+        'macrogroups/<slug:slug>/',
+        login_required(MacroGroupDetailView.as_view()),
+        name='macrogroup-detail'
+    ),
 
     # group urls
-    path('groups/', login_required(GroupListView.as_view()), name='group-list'),
-    path('groups/add/', login_required(GroupCreateView.as_view()), name='group-add'),
-    path('groups/update/<slug:slug>/', login_required(GroupUpdateView.as_view()), name='group-update'),
-    path('groups/delete/<slug:slug>/', login_required(GroupDeleteView.as_view()), name='group-delete'),
-    path('groups/<slug:slug>/', login_required(GroupDetailView.as_view()), name='group-detail'),
-    path('jx/groups/<slug:slug>/setpanoramic/<project_type>/<int:project_id>/',
-        login_required(GroupSetProjectPanoramicView.as_view()), name='group-set-project-panoramic'),
-    path('jx/groups/<slug:slug>/setpanoramic/<project_type>/<project_id>/',
-        login_required(GroupSetProjectPanoramicView.as_view()), name='group-set-project-panoramic'),
+    path(
+        'groups/',
+        login_required(GroupListView.as_view()),
+        name='group-list'
+    ),
+
+    path(
+        'groups/add/',
+        login_required(GroupCreateView.as_view()),
+        name='group-add'
+    ),
+
+    path(
+        'groups/update/<slug:slug>/',
+        login_required(GroupUpdateView.as_view()),
+        name='group-update'
+    ),
+
+    path(
+        'groups/delete/<slug:slug>/',
+        login_required(GroupDeleteView.as_view()),
+        name='group-delete'
+    ),
+
+    path(
+        'groups/<slug:slug>/',
+        login_required(GroupDetailView.as_view()),
+        name='group-detail'
+    ),
+
+    path(
+        'jx/groups/<slug:slug>/setpanoramic/<project_type>/<int:project_id>/',
+        login_required(GroupSetProjectPanoramicView.as_view()),
+        name='group-set-project-panoramic'
+    ),
+    
+    path(
+        'jx/groups/<slug:slug>/setpanoramic/<project_type>/<project_id>/',
+        login_required(GroupSetProjectPanoramicView.as_view()),
+        name='group-set-project-panoramic'
+    ),
 
     # project urls
-    path('groups/<slug:group_slug>/projects/', login_required(ProjectListView.as_view()),
-        name='project-list'),
+    path(
+        'groups/<slug:group_slug>/projects/',
+        login_required(ProjectListView.as_view()),
+        name='project-list'
+    ),
 
-    path('generalsuitedata/', login_required(GeneralSuiteDataUpdateView.as_view()), name='generaldata-update'),
-    path('search/', login_required(SearchAdminView.as_view()), name='search-admin')
+    path(
+        'generalsuitedata/',
+        login_required(GeneralSuiteDataUpdateView.as_view()),
+        name='generaldata-update'
+    ),
 
-
+    path(
+        'search/',
+        login_required(SearchAdminView.as_view()),
+        name='search-admin'
+    )
 
 ]
-

--- a/g3w-admin/editing/apiurls.py
+++ b/g3w-admin/editing/apiurls.py
@@ -7,23 +7,35 @@ from .api.info.views import *
 BASE_URLS = 'vector'
 
 urlpatterns = [
-    re_path(r'^api/(?P<mode_call>editing|commit|unlock)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/'
+    re_path(
+        r'^api/(?P<mode_call>editing|commit|unlock)/(?P<project_type>[-_\w\d]+)/(?P<project_id>[0-9]+)/'
         r'(?P<layer_name>[-_\w\d]+)/$',
-        layer_commit_vector_view, name='editing-commit-vector-api')
+        layer_commit_vector_view,
+        name='editing-commit-vector-api'
+    )
 ]
 
 # Editing info
 urlpatterns += [
     # Other vector layers in project get by qdjango layer id
-    re_path(r'^api/info/layer/(?P<editing_layer_id>[-_\w\d]+)/$',
-        login_required(EditingLayerInfo.as_view()), name='editing-api-info-layer'),
+    re_path(
+        r'^api/info/layer/(?P<editing_layer_id>[-_\w\d]+)/$',
+        login_required(EditingLayerInfo.as_view()),
+        name='editing-api-info-layer'
+    ),
 
     # Viewers users can editing on editing layer id
-    re_path(r'^api/info/layer/user/(?P<editing_layer_id>[-_\w\d]+)/$',
-        login_required(EditingLayerUserInfo.as_view()), name='editing-api-info-layer-user'),
+    re_path(
+        r'^api/info/layer/user/(?P<editing_layer_id>[-_\w\d]+)/$',
+        login_required(EditingLayerUserInfo.as_view()),
+        name='editing-api-info-layer-user'
+    ),
 
     # Viewers users groups viewer can editing on editing layer id
-    re_path(r'^api/info/layer/authgroup/(?P<editing_layer_id>[-_\w\d]+)/$',
-        login_required(EditingLayerAuthGroupInfo.as_view()), name='editing-api-info-layer-authgroup'),
+    re_path(
+        r'^api/info/layer/authgroup/(?P<editing_layer_id>[-_\w\d]+)/$',
+        login_required(EditingLayerAuthGroupInfo.as_view()),
+        name='editing-api-info-layer-authgroup'
+    ),
 ]
 

--- a/g3w-admin/editing/urls.py
+++ b/g3w-admin/editing/urls.py
@@ -3,8 +3,16 @@ from django.contrib.auth.decorators import login_required
 from .views import UploadFileView, ActiveEditingLayerView
 
 urlpatterns = [
-    path('upload/', UploadFileView.as_view(), name='editing-upload'),
-    re_path('^(?P<group_slug>[-_\w\d]+)/(?P<project_type>[-_\w\d]+)/(?P<project_slug>[-_\w\d]+)/(?P<layer_id>[0-9]+)/'
+    path(
+        'upload/',
+        UploadFileView.as_view(),
+        name='editing-upload'
+    ),
+
+    re_path(
+        '^(?P<group_slug>[-_\w\d]+)/(?P<project_type>[-_\w\d]+)/(?P<project_slug>[-_\w\d]+)/(?P<layer_id>[0-9]+)/'
         r'active/$',
-        login_required(ActiveEditingLayerView.as_view()), name='editing-layer-active'),
+        login_required(ActiveEditingLayerView.as_view()),
+        name='editing-layer-active'
+    ),
 ]

--- a/g3w-admin/filemanager/apiurls.py
+++ b/g3w-admin/filemanager/apiurls.py
@@ -3,5 +3,9 @@ from django.contrib.auth.decorators import login_required
 from .views import files_view
 
 urlpatterns = [
-    path('api/files/', login_required(files_view), name='filemanager-logic'),
+    path(
+        'api/files/',
+        login_required(files_view),
+        name='filemanager-logic'
+    ),
 ]

--- a/g3w-admin/filemanager/urls.py
+++ b/g3w-admin/filemanager/urls.py
@@ -7,7 +7,15 @@ from .views import *
 G3W_SITETREE_I18N_ALIAS.append('filemanager_sidebar_right')
 
 urlpatterns = [
-    path('', login_required(FilemanagerView.as_view()), name='filemanager-home'),
-    re_path(r'^config/(?P<file_js>[-_\.\\\w\d]+)$', login_required(FilemanagerServeConfigView.as_view()),
-       name='filemanager-serve-file-config'),
+    path(
+        '',
+        login_required(FilemanagerView.as_view()),
+        name='filemanager-home'
+    ),
+
+    re_path(
+        r'^config/(?P<file_js>[-_\.\\\w\d]+)$',
+        login_required(FilemanagerServeConfigView.as_view()),
+       name='filemanager-serve-file-config'
+    ),
 ]

--- a/g3w-admin/openrouteservice/apiurls.py
+++ b/g3w-admin/openrouteservice/apiurls.py
@@ -25,12 +25,27 @@ from .api.views import (
 BASE_URLS = 'openrouteservice'
 
 urlpatterns = [
-    re_path(r'^api/compatible_layers/(?P<project_id>[0-9]+)/$', login_required(
-        OpenrouteserviceCompatibleLayersView.as_view()), name='openrouteservice-compatible-layers'),
-    re_path(r'^api/isochrone/(?P<project_id>[0-9]+)/$', login_required(
-        OpenrouteServiceIsochroneView.as_view()), name='openrouteservice-isochrone'),
-    re_path(r'^api/isochrone_from_layer/(?P<project_id>[0-9]+)/(?P<layer_id>[0-9]+)$', login_required(
-        OpenrouteServiceIsochroneFromLayerView.as_view()), name='openrouteservice-isochrone-from-layer'),
-    re_path(r'^api/isochrone_from_layer_result/(?P<project_id>[0-9]+)/(?P<task_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12})$', login_required(
-        OpenrouteServiceIsochroneFromLayerResultView.as_view()), name='openrouteservice-isochrone-from-layer-result'),
+    re_path(
+        r'^api/compatible_layers/(?P<project_id>[0-9]+)/$',
+        login_required(OpenrouteserviceCompatibleLayersView.as_view()),
+        name='openrouteservice-compatible-layers'
+    ),
+
+    re_path(
+        r'^api/isochrone/(?P<project_id>[0-9]+)/$',
+        login_required(OpenrouteServiceIsochroneView.as_view()),
+        name='openrouteservice-isochrone'
+    ),
+
+    re_path(
+        r'^api/isochrone_from_layer/(?P<project_id>[0-9]+)/(?P<layer_id>[0-9]+)$',
+        login_required(OpenrouteServiceIsochroneFromLayerView.as_view()),
+        name='openrouteservice-isochrone-from-layer'
+    ),
+
+    re_path(
+        r'^api/isochrone_from_layer_result/(?P<project_id>[0-9]+)/(?P<task_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12})$',
+        login_required(OpenrouteServiceIsochroneFromLayerResultView.as_view()),
+        name='openrouteservice-isochrone-from-layer-result'
+    ),
 ]

--- a/g3w-admin/openrouteservice/urls.py
+++ b/g3w-admin/openrouteservice/urls.py
@@ -19,15 +19,27 @@ from django.contrib.auth.decorators import login_required
 
 
 urlpatterns = [
-    path('openrouteservice/projects/',
-         login_required(OpenrouteserviceProjectList.as_view()), name='ors-project-list'),
     path(
-        'openrouteservice/project/add/', login_required(
-            OpenrouteserviceProjectCreate.as_view()), name='ors-project-add'),
+        'openrouteservice/projects/',
+         login_required(OpenrouteserviceProjectList.as_view()),
+         name='ors-project-list'
+    ),
+
     path(
-        'openrouteservice/project/<int:pk>/', login_required(
-            OpenrouteserviceProjectUpdate.as_view()), name='ors-project-update'),
+        'openrouteservice/project/add/',
+        login_required(OpenrouteserviceProjectCreate.as_view()),
+        name='ors-project-add'
+    ),
+
     path(
-        'openrouteservice/project/delete/<int:pk>/', login_required(
-            OpenrouteserviceProjectDelete.as_view()), name='ors-project-delete'),
+        'openrouteservice/project/<int:pk>/',
+        login_required(OpenrouteserviceProjectUpdate.as_view()),
+        name='ors-project-update'
+    ),
+
+    path(
+        'openrouteservice/project/delete/<int:pk>/',
+        login_required(OpenrouteserviceProjectDelete.as_view()),
+        name='ors-project-delete'
+    ),
 ]

--- a/g3w-admin/qdjango/apiurls.py
+++ b/g3w-admin/qdjango/apiurls.py
@@ -55,174 +55,291 @@ urlpatterns = [
     # Subset string rules
 
     # Detail of a subsetstringrule
-    path('api/subsetstringrule/detail/<int:pk>/',
-         login_required(ConstraintSubsetStringRuleDetail.as_view()), name='qdjango-subsetstringrule-api-detail'),
+    path(
+        'api/subsetstringrule/detail/<int:pk>/',
+        login_required(ConstraintSubsetStringRuleDetail.as_view()),
+        name='qdjango-subsetstringrule-api-detail'
+    ),
 
     # All subsetstringrule(s) filtered by layer qdjango layer pk
-    path('api/subsetstringrule/layer/<int:layer_id>/', login_required(ConstraintSubsetStringRuleList.as_view()),
-         name='qdjango-subsetstringrule-api-filter-by-layer-id'),
+    path(
+        'api/subsetstringrule/layer/<int:layer_id>/',
+        login_required(ConstraintSubsetStringRuleList.as_view()),
+        name='qdjango-subsetstringrule-api-filter-by-layer-id'
+    ),
 
     # All subsetstringrule(s) filtered by User pk
-    path('api/subsetstringrule/user/<int:user_id>/', login_required(ConstraintSubsetStringRuleList.as_view()),
-         name='qdjango-subsetstringrule-api-filter-by-user'),
+    path(
+        'api/subsetstringrule/user/<int:user_id>/',
+        login_required(ConstraintSubsetStringRuleList.as_view()),
+        name='qdjango-subsetstringrule-api-filter-by-user'
+    ),
 
     # All subsetstringrule(s) filtered by Constraint pk
-    path('api/subsetstringrule/constraint/<int:constraint_id>/',
-         login_required(ConstraintSubsetStringRuleList.as_view()),
-         name='qdjango-subsetstringrule-api-filter-by-constraint'),
+    path(
+        'api/subsetstringrule/constraint/<int:constraint_id>/',
+        login_required(ConstraintSubsetStringRuleList.as_view()),
+        name='qdjango-subsetstringrule-api-filter-by-constraint'
+    ),
 
     # All subsetstringrule(s)
-    path('api/subsetstringrule/', login_required(ConstraintSubsetStringRuleList.as_view()),
-         name='qdjango-subsetstringrule-api-list'),
+    path(
+        'api/subsetstringrule/',
+        login_required(ConstraintSubsetStringRuleList.as_view()),
+        name='qdjango-subsetstringrule-api-list'
+    ),
 
     #############################################################
     # Expression rules
 
     # Detail of a expression rule
-    path('api/expressionrule/detail/<int:pk>/', login_required(ConstraintExpressionRuleDetail.as_view()),
-         name='qdjango-expressionrule-api-detail'),
+    path(
+        'api/expressionrule/detail/<int:pk>/',
+        login_required(ConstraintExpressionRuleDetail.as_view()),
+        name='qdjango-expressionrule-api-detail'
+    ),
 
     # All expressionrule(s) filtered by layer qdjango layer pk
-    path('api/expressionrule/layer/<int:layer_id>/', login_required(ConstraintExpressionRuleList.as_view()),
-         name='qdjango-expressionrule-api-filter-by-layer-id'),
+    path(
+        'api/expressionrule/layer/<int:layer_id>/',
+        login_required(ConstraintExpressionRuleList.as_view()),
+        name='qdjango-expressionrule-api-filter-by-layer-id'
+    ),
 
     # All expressionrule(s) filtered by User pk
-    path('api/expressionrule/user/<int:user_id>/', login_required(ConstraintExpressionRuleList.as_view()),
-         name='qdjango-expressionrule-api-filter-by-user'),
+    path(
+        'api/expressionrule/user/<int:user_id>/',
+        login_required(ConstraintExpressionRuleList.as_view()),
+        name='qdjango-expressionrule-api-filter-by-user'
+    ),
 
     # All expressionrule(s) filtered by Constraint pk
-    path('api/expressionrule/constraint/<int:constraint_id>/', login_required(ConstraintExpressionRuleList.as_view()),
-         name='qdjango-expressionrule-api-filter-by-constraint'),
+    path(
+        'api/expressionrule/constraint/<int:constraint_id>/',
+        login_required(ConstraintExpressionRuleList.as_view()),
+        name='qdjango-expressionrule-api-filter-by-constraint'
+    ),
 
     # All expressionrule(s)
-    path('api/expressionrule/', login_required(ConstraintExpressionRuleList.as_view()),
-         name='qdjango-expressionrule-api-list'),
+    path(
+        'api/expressionrule/',
+        login_required(ConstraintExpressionRuleList.as_view()),
+        name='qdjango-expressionrule-api-list'
+    ),
 
 
     #############################################################
     # Constraints
 
     # Detail of a Constraint
-    path('api/constraint/detail/<int:pk>/', login_required(SingleLayerConstraintDetail.as_view()),
-         name='qdjango-constraint-api-detail'),
+    path(
+        'api/constraint/detail/<int:pk>/',
+        login_required(SingleLayerConstraintDetail.as_view()),
+        name='qdjango-constraint-api-detail'
+    ),
 
     # All Constraint(s) filtered by layer qdjango layer pk
-    path('api/constraint/layer/<int:layer_id>/', login_required(SingleLayerConstraintList.as_view()),
-         name='qdjango-constraint-api-filter-by-layer-id'),
+    path(
+        'api/constraint/layer/<int:layer_id>/',
+        login_required(SingleLayerConstraintList.as_view()),
+        name='qdjango-constraint-api-filter-by-layer-id'
+    ),
 
     # All Constraint(s) filtered by user
-    path('api/constraint/user/<int:user_id>/', login_required(SingleLayerConstraintList.as_view()),
-         name='qdjango-constraint-api-filter-by-user'),
+    path(
+        'api/constraint/user/<int:user_id>/',
+        login_required(SingleLayerConstraintList.as_view()),
+        name='qdjango-constraint-api-filter-by-user'
+    ),
 
     # All Constraint(s)
-    path('api/constraint/', login_required(SingleLayerConstraintList.as_view()), name='qdjango-constraint-api-list'),
+    path(
+        'api/constraint/',
+        login_required(SingleLayerConstraintList.as_view()),
+        name='qdjango-constraint-api-list'
+    ),
 
     #############################################################
     # ColumnAcl
 
     # Detail of a ColumnAcl
-    path('api/column_acl/detail/<int:pk>/', login_required(ColumnAclDetail.as_view()),
-         name='qdjango-column-acl-api-detail'),
+    path(
+        'api/column_acl/detail/<int:pk>/',
+        login_required(ColumnAclDetail.as_view()),
+        name='qdjango-column-acl-api-detail'
+    ),
 
     # All (s) ColumnAcl filtered by layer qdjango layer pk
-    path('api/column_acl/layer/<int:layer_id>/',
-        login_required(ColumnAclList.as_view()), name='qdjango-column-acl-api-filter-by-layer-id'),
+    path(
+        'api/column_acl/layer/<int:layer_id>/',
+        login_required(ColumnAclList.as_view()),
+        name='qdjango-column-acl-api-filter-by-layer-id'
+    ),
 
     # All Constraint(s) filtered by user
-    path('api/column_acl/user/<int:user_id>/',
-        login_required(ColumnAclList.as_view()), name='qdjango-column-acl-api-filter-by-user'),
+    path(
+        'api/column_acl/user/<int:user_id>/',
+        login_required(ColumnAclList.as_view()),
+        name='qdjango-column-acl-api-filter-by-user'
+    ),
 
     # All Constraint(s) filtered by group
-    path('api/column_acl/group/<int:group_id>/',
-        login_required(ColumnAclList.as_view()), name='qdjango-column-acl-api-filter-by-group'),
+    path(
+        'api/column_acl/group/<int:group_id>/',
+        login_required(ColumnAclList.as_view()),
+        name='qdjango-column-acl-api-filter-by-group'
+    ),
 
     # List field names for a vector layer
-    path('api/column_acl/fields/<int:layer_id>/',
-        login_required(ColumnAclFields.as_view()), name='qdjango-column-acl-api-fields'),
+    path(
+        'api/column_acl/fields/<int:layer_id>/',
+        login_required(ColumnAclFields.as_view()),
+        name='qdjango-column-acl-api-fields'
+    ),
 
     # All Constraint(s)
-    path('api/column_acl/',
-        login_required(ColumnAclList.as_view()), name='qdjango-column-acl-api-list'),
+    path(
+        'api/column_acl/',
+        login_required(ColumnAclList.as_view()),
+        name='qdjango-column-acl-api-list'
+    ),
 
 
     #############################################################
     # GeoConstraints
 
     # Detail of a GeoConstraintRule
-    path('api/georule/detail/<int:pk>/',
-        login_required(GeoConstraintRuleDetail.as_view()), name='geoconstraintrule-api-detail'),
+    path(
+        'api/georule/detail/<int:pk>/',
+        login_required(GeoConstraintRuleDetail.as_view()),
+        name='geoconstraintrule-api-detail'
+    ),
 
     # All ConstraintRule(s) filtered by editing layer id
-    re_path(r'^api/georule/layer/(?P<layer_id>[-_\w\d]+)/$',
-        login_required(GeoConstraintRuleList.as_view()), name='geoconstraintrule-api-filter-by-layer'),
+    re_path(
+        r'^api/georule/layer/(?P<layer_id>[-_\w\d]+)/$',
+        login_required(GeoConstraintRuleList.as_view()),
+        name='geoconstraintrule-api-filter-by-layer'
+    ),
 
     # All ConstraintRule(s) filtered by User pk
-    path('api/georule/user/<int:user_id>/',
-        login_required(GeoConstraintRuleList.as_view()), name='geoconstraintrule-api-filter-by-user'),
+    path(
+        'api/georule/user/<int:user_id>/',
+        login_required(GeoConstraintRuleList.as_view()),
+        name='geoconstraintrule-api-filter-by-user'
+    ),
 
     # All ConstraintRule(s) filtered by Constraint pk
-    path('api/georule/geoconstraint/<int:constraint_id>/',
-        login_required(GeoConstraintRuleList.as_view()), name='geoconstraintrule-api-filter-by-constraint'),
+    path(
+        'api/georule/geoconstraint/<int:constraint_id>/',
+        login_required(GeoConstraintRuleList.as_view()),
+        name='geoconstraintrule-api-filter-by-constraint'
+    ),
 
     # All ConstraintRule(s)
-    path('api/georule/',
-        login_required(GeoConstraintRuleList.as_view()), name='geoconstraintrule-api-list'),
+    path(
+        'api/georule/',
+        login_required(GeoConstraintRuleList.as_view()),
+        name='geoconstraintrule-api-list'
+    ),
 
     # Constraint geometry
-    re_path(r'^api/geoconstraint/geometry/(?P<layer_id>[-_\w\d]+)/$',
-        login_required(GeoConstraintGEOFeatureAPIView.as_view()), name='geoconstraint-api-geometry'),
+    re_path(
+        r'^api/geoconstraint/geometry/(?P<layer_id>[-_\w\d]+)/$',
+        login_required(GeoConstraintGEOFeatureAPIView.as_view()),
+        name='geoconstraint-api-geometry'
+    ),
 
     # Detail of a Constraint
-    path('api/geoconstraint/detail/<int:pk>/',
-        login_required(GeoConstraintDetail.as_view()), name='geoconstraint-api-detail'),
+    path(
+        'api/geoconstraint/detail/<int:pk>/',
+        login_required(GeoConstraintDetail.as_view()),
+        name='geoconstraint-api-detail'
+    ),
 
     # All Constraint(s) filtered by editing layer id
-    re_path(r'^api/geoconstraint/(?P<layer_id>[-_\w\d]+)/$',
-        login_required(GeoConstraintList.as_view()), name='geoconstraint-api-filter-by-layer'),
+    re_path(
+        r'^api/geoconstraint/(?P<layer_id>[-_\w\d]+)/$',
+        login_required(GeoConstraintList.as_view()),
+        name='geoconstraint-api-filter-by-layer'
+    ),
 
     # All Constraint(s)
-    path('api/geoconstraint/',
-        login_required(GeoConstraintList.as_view()), name='geoconstraint-api-list'),
+    path(
+        'api/geoconstraint/',
+        login_required(GeoConstraintList.as_view()),
+        name='geoconstraint-api-list'
+    ),
 
 
     #############################################################
     # OGC (web) services
 
     # All Service(s)
-    path('api/webservice/<int:project_id>/',
-        login_required(QdjangoWebServicesAPIview.as_view()), name='qdjango-webservice-api-list'),
+    path(
+        'api/webservice/<int:project_id>/',
+        login_required(QdjangoWebServicesAPIview.as_view()),
+        name='qdjango-webservice-api-list'
+    ),
 
     #############################################################
     # General API
-    path('api/asgeotiff/<int:project_id>/',
-        QdjangoAsGeoTiffAPIview.as_view(), name='qdjango-asgeotiff-api'),
-    re_path(r'^api/prjtheme/(?P<project_id>\d+)/(?P<theme_name>[-_\w\d\s]+)/$',
-        QdjangoPrjThemeAPIview.as_view(), name='qdjango-prjtheme-api'),
+    path(
+        'api/asgeotiff/<int:project_id>/',
+        QdjangoAsGeoTiffAPIview.as_view(),
+        name='qdjango-asgeotiff-api'
+    ),
+    re_path(
+        r'^api/prjtheme/(?P<project_id>\d+)/(?P<theme_name>[-_\w\d\s]+)/$',
+        QdjangoPrjThemeAPIview.as_view(),
+        name='qdjango-prjtheme-api'
+    ),
 
     # Order
     # ============================================================
-    path('jx/project/<int:project_id>/setorder/', login_required(ProjectSetOrderView.as_view()),
-         name='qdjango-project-set-order'),
+    path(
+        'jx/project/<int:project_id>/setorder/',
+        login_required(ProjectSetOrderView.as_view()),
+        name='qdjango-project-set-order'
+    ),
 
 ]
 
 # Layer style manager
 urlpatterns += [
-    path('api/layerstyles/<int:layer_id>/',
-        login_required(LayerStyleListView.as_view()), name='qdjango-style-list-api'),
-    re_path(r'^api/layerstyles/(?P<layer_id>\d+)/(?P<style_name>[\w\s%-]+)/$',
-        login_required(LayerStyleDetailView.as_view()), name='qdjango-style-detail-api'),
+    path(
+        'api/layerstyles/<int:layer_id>/',
+        login_required(LayerStyleListView.as_view()),
+        name='qdjango-style-list-api'
+    ),
+
+    re_path(
+        r'^api/layerstyles/(?P<layer_id>\d+)/(?P<style_name>[\w\s%-]+)/$',
+        login_required(LayerStyleDetailView.as_view()),
+        name='qdjango-style-detail-api'
+    ),
 ]
 
 # API info
 urlpatterns += [
     # Other vector layers in project get by qdjango layer id
-    re_path(r'^api/info/layer/polygon/(?P<layer_id>[-_\w\d]+)/$',
-        login_required(LayerPolygonView.as_view()), name='qdjango-api-info-layer-polygon'),
+    re_path(
+        r'^api/info/layer/polygon/(?P<layer_id>[-_\w\d]+)/$',
+        login_required(LayerPolygonView.as_view()),
+        name='qdjango-api-info-layer-polygon'
+    ),
+
     # Viewers users can editing on editing layer id
-    re_path(r'^api/info/layer/user/(?P<layer_id>[-_\w\d]+)/$',
-        login_required(LayerUserInfoAPIView.as_view()), name='qdjango-api-info-layer-user'),
+    re_path(
+        r'^api/info/layer/user/(?P<layer_id>[-_\w\d]+)/$',
+        login_required(LayerUserInfoAPIView.as_view()),
+        name='qdjango-api-info-layer-user'
+    ),
+
     # Viewers users groups viewer can editing on editing layer id
-    re_path(r'^api/info/layer/authgroup/(?P<layer_id>[-_\w\d]+)/$',
-        login_required(LayerAuthGroupInfoAPIView.as_view()), name='qdjango-api-info-layer-authgroup'),
+    re_path(
+        r'^api/info/layer/authgroup/(?P<layer_id>[-_\w\d]+)/$',
+        login_required(LayerAuthGroupInfoAPIView.as_view()),
+        name='qdjango-api-info-layer-authgroup'
+    ),
 ]

--- a/g3w-admin/qdjango/urls.py
+++ b/g3w-admin/qdjango/urls.py
@@ -6,52 +6,118 @@ from .views import *
 G3W_SITETREE_I18N_ALIAS.append('qdjango')
 
 urlpatterns = [
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/$', login_required(QdjangoProjectListView.as_view()),
-        name='qdjango-project-list'),
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/project/add/$', login_required(QdjangoProjectCreateView.as_view()),
-        name='qdjango-project-add'),
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/update/(?P<slug>[-_\w\d]+)/$',
-        login_required(QdjangoProjectUpdateView.as_view()), name='qdjango-project-update'),
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/delete/(?P<slug>[-_\w\d]+)/$',
-        login_required(QdjangoProjectDeleteView.as_view()), name='qdjango-project-delete'),
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<slug>[-_\w\d]+)/$',
-        login_required(QdjangoProjectDetailView.as_view()), name='qdjango-project-detail'),
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/download/(?P<slug>[-_\w\d]+)/$',
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/$',
+        login_required(QdjangoProjectListView.as_view()),
+        name='qdjango-project-list'
+    ),
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/project/add/$',
+        login_required(QdjangoProjectCreateView.as_view()),
+        name='qdjango-project-add'
+    ),
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/update/(?P<slug>[-_\w\d]+)/$',
+        login_required(QdjangoProjectUpdateView.as_view()),
+        name='qdjango-project-update'
+    ),
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/delete/(?P<slug>[-_\w\d]+)/$',
+        login_required(QdjangoProjectDeleteView.as_view()),
+        name='qdjango-project-delete'
+    ),
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<slug>[-_\w\d]+)/$',
+        login_required(QdjangoProjectDetailView.as_view()),
+        name='qdjango-project-detail'
+    ),
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/download/(?P<slug>[-_\w\d]+)/$',
         login_required(QdjangoProjectDownloadView.as_view(model=Project, file_field='qgis_file')),
-        name='qdjango-project-download'),
+        name='qdjango-project-download'
+    ),
 
     # for ajaxFiler
     re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/fast/update/(?P<slug>[-_\w\d]+)/$',
         login_required(QdjangoProjectFastUpdateView.as_view()), name='qdjango-project-fast-update'),
 
+    #############################################################
     # Layers re_paths
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layers/$',
-        login_required(QdjangoLayersListView.as_view()), name='qdjango-project-layers-list'),
-    re_path(r'^jx/(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layers/(?P<layer_id>[0-9]+)/cache/$',
-        login_required(QdjangoLayerCacheView.as_view()), name='qdjango-project-layers-cache'),
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layer/(?P<layer_slug>[-_\w\d]+)/widgets/$',
-        login_required(QdjangoLayerWidgetsView.as_view()), name='qdjango-project-layer-widgets'),
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<slug>[-_\w\d]+)/layer/(?P<pk>[0-9]+)/detail/$',
-        login_required(QdjangoLayerDetailView.as_view()), name='qdjango-layer-detail'),
 
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layers/$',
+        login_required(QdjangoLayersListView.as_view()),
+        name='qdjango-project-layers-list'
+    ),
+
+    re_path(
+        r'^jx/(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layers/(?P<layer_id>[0-9]+)/cache/$',
+        login_required(QdjangoLayerCacheView.as_view()),
+        name='qdjango-project-layers-cache'
+    ),
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layer/(?P<layer_slug>[-_\w\d]+)/widgets/$',
+        login_required(QdjangoLayerWidgetsView.as_view()),
+        name='qdjango-project-layer-widgets'
+    ),
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<slug>[-_\w\d]+)/layer/(?P<pk>[0-9]+)/detail/$',
+        login_required(QdjangoLayerDetailView.as_view()),
+        name='qdjango-layer-detail'
+    ),
+
+    #############################################################
     # for data layer by ajax
-    re_path(r'^jx/(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layers/(?P<layer_id>[0-9]+)/data/$',
-        login_required(QdjangoLayerDataView.as_view()), name='qdjango-project-layers-data-editing'),
 
+    re_path(
+        r'^jx/(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layers/(?P<layer_id>[0-9]+)/data/$',
+        login_required(QdjangoLayerDataView.as_view()),
+        name='qdjango-project-layers-data-editing'
+    ),
+
+    #############################################################
     # Widget re_paths
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layer/(?P<layer_slug>[-_\w\d]+)/widgets/add/$',
-        login_required(QdjangoLayerWidgetCreateView.as_view()), name='qdjango-project-layer-widget-add'),
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layer/(?P<layer_slug>[-_\w\d]+)/widgets/update/(?P<slug>[-_\w\d]+)$',
-        login_required(QdjangoLayerWidgetUpdateView.as_view()), name='qdjango-project-layer-widget-update'),
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layer/(?P<layer_slug>[-_\w\d]+)/widgets/delete/(?P<slug>[-_\w\d]+)$',
-        login_required(QdjangoLayerWidgetDeleteView.as_view()), name='qdjango-project-layer-widget-delete'),
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layer/(?P<layer_slug>[-_\w\d]+)/widgets/link/(?P<slug>[-_\w\d]+)$',
-        login_required(QdjangoLinkWidget2LayerView.as_view()), name='qdjango-project-layer-widget-link'),
 
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layer/(?P<layer_slug>[-_\w\d]+)/widgets/add/$',
+        login_required(QdjangoLayerWidgetCreateView.as_view()),
+        name='qdjango-project-layer-widget-add'
+    ),
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layer/(?P<layer_slug>[-_\w\d]+)/widgets/update/(?P<slug>[-_\w\d]+)$',
+        login_required(QdjangoLayerWidgetUpdateView.as_view()),
+        name='qdjango-project-layer-widget-update'
+    ),
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layer/(?P<layer_slug>[-_\w\d]+)/widgets/delete/(?P<slug>[-_\w\d]+)$',
+        login_required(QdjangoLayerWidgetDeleteView.as_view()),
+        name='qdjango-project-layer-widget-delete'
+    ),
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/projects/(?P<project_slug>[-_\w\d]+)/layer/(?P<layer_slug>[-_\w\d]+)/widgets/link/(?P<slug>[-_\w\d]+)$',
+        login_required(QdjangoLinkWidget2LayerView.as_view()),
+        name='qdjango-project-layer-widget-link'
+    ),
+
+    #############################################################
     # Filter by user/group re_paths
-    re_path(r'^(?P<group_slug>[-_\w\d]+)/(?P<project_type>[-_\w\d]+)/(?P<project_slug>[-_\w\d]+)/(?P<layer_id>[0-9]+)/'
+
+    re_path(
+        r'^(?P<group_slug>[-_\w\d]+)/(?P<project_type>[-_\w\d]+)/(?P<project_slug>[-_\w\d]+)/(?P<layer_id>[0-9]+)/'
         r'filterbyuser/$',
-        login_required(FilterByUserLayerView.as_view()), name='fitler-by-user-layer'),
+        login_required(FilterByUserLayerView.as_view()),
+        name='fitler-by-user-layer'
+    ),
 
 ]
 
@@ -62,13 +128,21 @@ try:
     #get qdjango sitetree and add items to core sitetree:
 
     register_dynamic_trees(
-        compose_dynamic_tree('qdjango', target_tree_alias='core', parent_tree_item_alias='project-list',
-                             include_trees=('qdjango',)),
+        compose_dynamic_tree(
+            'qdjango',
+            target_tree_alias='core',
+            parent_tree_item_alias='project-list',
+            include_trees=('qdjango',)
+        ),
         reset_cache=True
     )
     register_dynamic_trees(
-        compose_dynamic_tree('qdjango', target_tree_alias='core_en', parent_tree_item_alias='project-list',
-                             include_trees=('qdjango_en',)),
+        compose_dynamic_tree(
+            'qdjango',
+            target_tree_alias='core_en',
+            parent_tree_item_alias='project-list',
+            include_trees=('qdjango_en',)
+        ),
         reset_cache=True
     )
 

--- a/g3w-admin/qplotly/apiurls.py
+++ b/g3w-admin/qplotly/apiurls.py
@@ -19,20 +19,39 @@ BASE_URLS = 'qplotly'
 
 urlpatterns = [
 
-    re_path(r'^api/trace/(?P<project_id>[0-9]+)/(?P<pk>\d+)/$', QplotlyTraceAPIView.as_view(), name='qplotly-api-trace'),
-    re_path(r'^api/trace/(?P<project_id>[0-9]+)/(?P<qgs_layer_id>[-_\w\d]+)/(?P<pk>\d+)/$', QplotlyTraceAPIView.as_view(),
-        name='qplotly-api-trace-qgs-layer-id'),
+    re_path(
+        r'^api/trace/(?P<project_id>[0-9]+)/(?P<pk>\d+)/$',
+        QplotlyTraceAPIView.as_view(),
+        name='qplotly-api-trace'
+    ),
+
+    re_path(
+        r'^api/trace/(?P<project_id>[0-9]+)/(?P<qgs_layer_id>[-_\w\d]+)/(?P<pk>\d+)/$',
+        QplotlyTraceAPIView.as_view(),
+        name='qplotly-api-trace-qgs-layer-id'
+    ),
 
     #############################################################
     # Widgets
 
     # Detail/Update
-    re_path(r'^api/widget/detail/(?P<project_id>\d+)/(?P<pk>\d+)/$',
-        login_required(QplotlyWidgetDetail.as_view()), name='qplotly-widget-api-detail'),
+    re_path(
+        r'^api/widget/detail/(?P<project_id>\d+)/(?P<pk>\d+)/$',
+        login_required(QplotlyWidgetDetail.as_view()),
+        name='qplotly-widget-api-detail'
+    ),
+
     # Widget(s) filter by layer_id
-    re_path(r'^api/widget/layer/(?P<layer_id>\d+)/$',
-        login_required(QplotlyWidgetList.as_view()), name='qplotly-widget-api-filter-by-layer-id'),
+    re_path(
+        r'^api/widget/layer/(?P<layer_id>\d+)/$',
+        login_required(QplotlyWidgetList.as_view()),
+        name='qplotly-widget-api-filter-by-layer-id'
+    ),
+
     # All Widget(s)
-    re_path(r'^api/widget/$',
-        login_required(QplotlyWidgetList.as_view()), name='qplotly-widget-api-list'),
+    re_path(
+        r'^api/widget/$',
+        login_required(QplotlyWidgetList.as_view()),
+        name='qplotly-widget-api-list'
+    ),
 ]

--- a/g3w-admin/qplotly/urls.py
+++ b/g3w-admin/qplotly/urls.py
@@ -16,11 +16,21 @@ from django.contrib.auth.decorators import login_required
 from .views import QplotlyLinkWidget2LayerView, QplotlyDownloadView, QplotlyWidgetShowOnStartClientView
 
 urlpatterns = [
-    path('layer/<int:layer_pk>/widgets/link/<int:pk>/',
-        login_required(QplotlyLinkWidget2LayerView.as_view()), name='qplotly-project-layer-widget-link'),
-    path('showonstartclient/<int:pk>/',
+    path(
+        'layer/<int:layer_pk>/widgets/link/<int:pk>/',
+        login_required(QplotlyLinkWidget2LayerView.as_view()),
+        name='qplotly-project-layer-widget-link'
+    ),
+
+    path(
+        'showonstartclient/<int:pk>/',
         login_required(QplotlyWidgetShowOnStartClientView.as_view()),
-        name='qplotly-project-layer-widget-showonstartclient'),
-    path('download/xml/<int:pk>/', login_required(QplotlyDownloadView.as_view()),
-        name='qplotly-download-xml')
+        name='qplotly-project-layer-widget-showonstartclient'
+    ),
+
+    path(
+        'download/xml/<int:pk>/',
+        login_required(QplotlyDownloadView.as_view()),
+        name='qplotly-download-xml'
+    )
 ]

--- a/g3w-admin/usersmanage/urls.py
+++ b/g3w-admin/usersmanage/urls.py
@@ -6,25 +6,71 @@ from usersmanage.views import *
 urlpatterns = [
 
     # user groups managment
-    path('users/groups/', login_required(UserGroupListView.as_view()), name='user-group-list'),
-    path('users/groups/add/', login_required(UserGroupCreateView.as_view()), name='user-group-add'),
-    path('users/groups/<int:pk>/', login_required(UserGroupDetailView.as_view()), name='user-group-detail'),
-    path('users/groups/update/<int:pk>/', login_required(UserGroupUpdateView.as_view()),
-        name='user-group-update'),
-    path('users/groups/delete/<int:pk>/', login_required(UserGroupAjaxDeleteView.as_view()),
-        name='user-group-delete'),
+    path(
+        'users/groups/',
+        login_required(UserGroupListView.as_view()),
+        name='user-group-list'
+    ),
 
-    path('jx/user/groups/byuserrole/', login_required(UserGroupByUserRoleView.as_view()),
-        name='user-group-by-user-role'),
+    path(
+        'users/groups/add/',
+        login_required(UserGroupCreateView.as_view()),
+        name='user-group-add'
+    ),
+
+    path(
+        'users/groups/<int:pk>/',
+        login_required(UserGroupDetailView.as_view()),
+        name='user-group-detail'
+    ),
+
+    path(
+        'users/groups/update/<int:pk>/',
+        login_required(UserGroupUpdateView.as_view()),
+        name='user-group-update'
+    ),
+
+    path(
+        'users/groups/delete/<int:pk>/',
+        login_required(UserGroupAjaxDeleteView.as_view()),
+        name='user-group-delete'
+    ),
+
+    path(
+        'jx/user/groups/byuserrole/',
+        login_required(UserGroupByUserRoleView.as_view()),
+        name='user-group-by-user-role'
+    ),
 
     # user management
-    path('users/', login_required(UserListView.as_view()), name='user-list'),
-    path('users/add/', login_required(UserCreateView.as_view()), name='user-add'),
-    path('users/<int:pk>/', login_required(UserDetailView.as_view()), name='user-detail'),
-    path('users/update/<int:pk>/', login_required(UserUpdateView.as_view()), name='user-update'),
-    path('users/delete/<int:pk>/', login_required(UserAjaxDeleteView.as_view()), name='user-delete'),
+    path(
+        'users/',
+        login_required(UserListView.as_view()),
+        name='user-list'
+    ),
 
+    path(
+        'users/add/',
+        login_required(UserCreateView.as_view()),
+        name='user-add'
+    ),
 
+    path(
+        'users/<int:pk>/',
+        login_required(UserDetailView.as_view()),
+        name='user-detail'
+    ),
 
+    path(
+        'users/update/<int:pk>/',
+        login_required(UserUpdateView.as_view()),
+        name='user-update'
+    ),
+
+    path(
+        'users/delete/<int:pk>/',
+        login_required(UserAjaxDeleteView.as_view()),
+        name='user-delete'
+    ),
 
 ]


### PR DESCRIPTION
List all functions parameters (eg. `path()` and `re_path()`) on multiple lines to slightly improve overall readability, eg:

## Before

```py
# g3w-admin\client\urls.py#L10

re_path(r'^map/(?P<map_name_alias>[-_\w\d]+)/$', client_map_alias_view, name='group-project-map-alias'),
```

## After

```py
# g3w-admin\client\urls.py#L10

re_path(
  r'^map/(?P<map_name_alias>[-_\w\d]+)/$',
  client_map_alias_view,
  name='group-project-map-alias'
),
```