### PR TITLE
Bypass `DatasourceExits` validator for raster and vector data loaded …

### DIFF
--- a/g3w-admin/qdjango/utils/validators.py
+++ b/g3w-admin/qdjango/utils/validators.py
@@ -358,7 +358,8 @@ class DatasourceExists(QgisProjectLayerValidator):
                 Layer.TYPES.ogr,
                 Layer.TYPES.raster,
                 Layer.TYPES.mdal
-        ] and not isXML(self.qgisProjectLayer.datasource):
+        ] and not isXML(self.qgisProjectLayer.datasource) \
+                and not self.qgisProjectLayer.datasource.startswith('/vsicurl/'):
 
             # try PostGis raster layer
             if self.qgisProjectLayer.datasource.startswith("PG:"):


### PR DESCRIPTION
…by HTTP/HTTPS/FTP protocol. Fix issue #424.

Closes: #424
