### PR TITLE
Refactoring settings parameter for custom CRS management.

### DIFF
--- a/g3w-admin/base/settings/base_geo_settings.py
+++ b/g3w-admin/base/settings/base_geo_settings.py
@@ -30,8 +30,13 @@ TILESTACHE_CONFIG_BASE = {
   "logging": "debug"
 }
 
-# Custom proj4 for EPSG:3003
-# --------------------------
+# Custom proj4 definitions for G3W-SUITE
+# --------------------------------------
 
-PROJ4_EPSG_3003 = "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl " \
-                  "+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs"
+G3W_PROJ4_EPSG = {
+  3003: "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl "
+        "+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
+  3004: "+proj=tmerc +lat_0=0 +lon_0=15 +k=0.9996 +x_0=2520000 +y_0=0 +ellps=intl "
+        "+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs +type=crs"
+}
+

--- a/g3w-admin/core/api/serializers.py
+++ b/g3w-admin/core/api/serializers.py
@@ -97,8 +97,8 @@ class GroupSerializer(G3WRequestSerializer, serializers.ModelSerializer):
         crs = QgsCoordinateReferenceSystem(f'EPSG:{self.instance.srid.srid}')
 
         # Patch for Proj4 > 4.9.3 version
-        if self.instance.srid.srid == 3003:
-            proj4 = settings.PROJ4_EPSG_3003
+        if self.instance.srid.srid in settings.G3W_PROJ4_EPSG.keys():
+            proj4 = settings.G3W_PROJ4_EPSG[self.instance.srid.srid]
         else:
             proj4 = crs.toProj4()
 

--- a/g3w-admin/core/api/views.py
+++ b/g3w-admin/core/api/views.py
@@ -263,8 +263,8 @@ class InterfaceOws(G3WAPIView):
             for srid in ows[al].crsOptions:
                 crs = QgsCoordinateReferenceSystem(srid)
 
-                if crs.postgisSrid() == 3003:
-                    proj4 = settings.PROJ4_EPSG_3003
+                if crs.postgisSrid() in settings.G3W_PROJ4_EPSG.keys():
+                    proj4 = settings.G3W_PROJ4_EPSG[crs.postgisSrid()]
                 else:
                     proj4 = crs.toProj4()
 

--- a/g3w-admin/qdjango/api/projects/serializers.py
+++ b/g3w-admin/qdjango/api/projects/serializers.py
@@ -728,7 +728,7 @@ class LayerSerializer(G3WRequestSerializer, serializers.ModelSerializer):
             crs = QgsCoordinateReferenceSystem(f'EPSG:{ret["crs"]}')
 
             # Patch for Proj4 > 4.9.3 version
-            if ret["crs"] in settings.G3W_PROJ4_EPSG.KEY():
+            if ret["crs"] in settings.G3W_PROJ4_EPSG.keys():
                 proj4 = settings.G3W_PROJ4_EPSG[ret["crs"]]
             else:
                 proj4 = crs.toProj4()

--- a/g3w-admin/qdjango/api/projects/serializers.py
+++ b/g3w-admin/qdjango/api/projects/serializers.py
@@ -728,9 +728,8 @@ class LayerSerializer(G3WRequestSerializer, serializers.ModelSerializer):
             crs = QgsCoordinateReferenceSystem(f'EPSG:{ret["crs"]}')
 
             # Patch for Proj4 > 4.9.3 version
-            if ret["crs"] == 3003:
-                proj4 = "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl " \
-                        "+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs"
+            if ret["crs"] in settings.G3W_PROJ4_EPSG.KEY():
+                proj4 = settings.G3W_PROJ4_EPSG[ret["crs"]]
             else:
                 proj4 = crs.toProj4()
 

--- a/pavement.py
+++ b/pavement.py
@@ -50,7 +50,7 @@ def kill(arg1, arg2):
         running = False
         for line in lines:
             # this kills all java.exe and python including self in windows
-            if ('%s' % arg2 in line) or (os.name == 'nt' and '%s' % arg1 in line):
+            if (bytes(arg2,'UTF-8') in line) or (os.name == 'nt' and bytes(arg2,'UTF-8') in line):
                 running = True
 
                 # Get pid
@@ -102,6 +102,26 @@ def requirements():
     info("Installing Python modules...")
     sh('pip install -r requirements.txt')
     sh('pip install -r requirements_huey.txt')
+    try:
+        sh('pip install -r g3w-admin/caching/requirements.txt')
+    except:
+        info("`Caching` module not active")
+
+    try:
+        sh('pip install -r g3w-admin/filemanager/requirements.txt')
+    except:
+        info("`Filemanager` module not active")
+
+    try:
+        sh('pip install -r g3w-admin/qplotly/requirements.txt')
+    except:
+        info("`Qplotly` module not active")
+
+    try:
+        sh('pip install -r g3w-admin/openrouteservice/requirements.txt')
+    except:
+        info("`Openrouteservice` module not active")
+
     info("Python modules installed.")
 
 


### PR DESCRIPTION
Refactoring of management of custom proj4 declaration, i.e. EPSG 3003 and 3004.
The settings parameter is `G3W_PROJ4_EPSG` and the default value is:

```python
G3W_PROJ4_EPSG = {
  3003: "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl "
        "+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
  3004: "+proj=tmerc +lat_0=0 +lon_0=15 +k=0.9996 +x_0=2520000 +y_0=0 +ellps=intl "
        "+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs +type=crs"
}
```

Closes: #437 
