### PR TITLE
Delete `.readthedocs.yml`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,0 @@
-version: 2
-formats: all
-sphinx:
-  configuration: docs/conf.py
-python:
-   version: 3.7
-   install:
-      - requirements: docs/requirements.txt


### PR DESCRIPTION
Related to: https://github.com/g3w-suite/g3w-admin/issues/375 and https://github.com/g3w-suite/g3w-admin/pull/413

Since v3.5 the documentation has been placed in dedicated repository: [g3w-suite/g3w-suite-documentation](https://github.com/g3w-suite/g3w-suite-documentation), so I guess this file should no longer be needed here..

**Fore more info:**

- [How to use the `.readthedocs.yaml` file](https://docs.readthedocs.io/en/stable/config-file/v2.html)