### PR TITLE
Remove native sentry monitor integration (raven config)

### DIFF
--- a/g3w-admin/base/settings/__init__.py
+++ b/g3w-admin/base/settings/__init__.py
@@ -29,24 +29,6 @@ try:
 except:
     pass
 
-if SENTRY:
-    try:
-        INSTALLED_APPS += ['raven.contrib.django.raven_compat']
-
-        import os
-        import raven
-
-        RAVEN_CONFIG = {
-            'dsn': 'https://fa7d5ea8d64e458e8848f9129462d38b:32352f9c4c8f43dba3c38780f68824ab@sentry.io/109745',
-            # If you are using git, you can also automatically configure the
-            # release based on the git info.
-            'release': raven.fetch_git_sha(os.path.dirname(os.path.dirname(
-                os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))),
-        }
-    except Exception:
-        pass
-
-
 if TESTING:
     try:
         from .tests_settings import *

--- a/g3w-admin/base/settings/base.py
+++ b/g3w-admin/base/settings/base.py
@@ -264,8 +264,6 @@ MPC = '-99:dodfEz3K2rziGayGnw_FyOuWdCM'
 FRONTEND = False
 FRONTEND_APP = 'frontend'
 
-SENTRY = False
-
 SITE_PREFIX_URL = None
 
 # CLIENT SETTINGS


### PR DESCRIPTION
The intent of this pull is to replace this integration with an opt-in package, ref: [g3w-admin-sentry-monitor](https://github.com/g3w-suite/g3w-admin-sentry-monitor) (WIP)

This also to ensure greater flexibility in terms of use (e.g. ensuring that the same sentry settings are applied regardless of the currently installed version of g3w-suite) and clarity towards the end user (eg. being able to set up a custom [DSN](https://docs.sentry.io/product/sentry-basics/dsn-explainer/) without drowning in hundreds of g3w-suite settings..)

Related to: https://github.com/g3w-suite/g3w-client/issues/68
