### PR TITLE
Fix removing layer from `layerstree` section inside repsonse of `/api/config` API REST when layer is filtered by user

### DIFF
--- a/g3w-admin/client/tests/test_api.py
+++ b/g3w-admin/client/tests/test_api.py
@@ -706,9 +706,13 @@ class ClientApiTest(CoreTestBase):
 
         self.assertTrue("Cities" in layers)
         self.assertTrue("Countries" in layers)
-
-        # check
         self.assertTrue("Rivers" in layers)
+
+        layerstree = json.dumps(jres['layerstree'])
+
+        self.assertTrue('"name": "Cities"' in layerstree)
+        self.assertTrue('"name": "Countries"' in layerstree)
+        self.assertTrue('"name": "Rivers"' in layerstree)
 
         layer_cities = self.project_print310.instance.layer_set.filter(name="Cities")
         layer_countries = self.project_print310.instance.layer_set.filter(name="Countries")
@@ -729,9 +733,13 @@ class ClientApiTest(CoreTestBase):
 
         self.assertFalse("Cities" in layers)
         self.assertTrue("Countries" in layers)
-
-        #check
         self.assertTrue("Rivers" in layers)
+
+        layerstree = json.dumps(jres['layerstree'])
+
+        self.assertFalse('"name": "Cities"' in layerstree)
+        self.assertTrue('"name": "Countries"' in layerstree)
+        self.assertTrue('"name": "Rivers"' in layerstree)
 
         self.client.logout()
 
@@ -749,12 +757,15 @@ class ClientApiTest(CoreTestBase):
 
         self.assertTrue("Cities" in layers)
         self.assertTrue("Countries" in layers)
-
-        # check
         self.assertTrue("Rivers" in layers)
 
-        self.client.logout()
+        layerstree = json.dumps(jres['layerstree'])
 
+        self.assertTrue('"name": "Cities"' in layerstree)
+        self.assertTrue('"name": "Countries"' in layerstree)
+        self.assertTrue('"name": "Rivers"' in layerstree)
+
+        self.client.logout()
 
         # login as viewer1.3 inside group gu_viewer2
         self.client.login(username=self.test_viewer1_3.username, password=self.test_viewer1_3.username)
@@ -767,9 +778,13 @@ class ClientApiTest(CoreTestBase):
 
         self.assertFalse("Cities" in layers)
         self.assertFalse("Countries" in layers)
-
-        # check
         self.assertTrue("Rivers" in layers)
+
+        layerstree = json.dumps(jres['layerstree'])
+
+        self.assertFalse('"name": "Cities"' in layerstree)
+        self.assertFalse('"name": "Countries"' in layerstree)
+        self.assertTrue('"name": "Rivers"' in layerstree)
 
         self.client.logout()
 
@@ -784,8 +799,12 @@ class ClientApiTest(CoreTestBase):
 
         self.assertTrue("Cities" in layers)
         self.assertTrue("Countries" in layers)
-
-        # check
         self.assertTrue("Rivers" in layers)
+
+        layerstree = json.dumps(jres['layerstree'])
+
+        self.assertTrue('"name": "Cities"' in layerstree)
+        self.assertTrue('"name": "Countries"' in layerstree)
+        self.assertTrue('"name": "Rivers"' in layerstree)
 
 

--- a/g3w-admin/qdjango/api/projects/serializers.py
+++ b/g3w-admin/qdjango/api/projects/serializers.py
@@ -81,25 +81,6 @@ class ProjectSerializer(G3WRequestSerializer, serializers.ModelSerializer):
 
 
             map_extent = get_crs_bbox(instance.group.srid.auth_srid)
-            # set max extent to CRS bounds
-            # if instance.group.srid.auth_srid == '4326':
-            #     rectangle = QgsCoordinateReferenceSystem('EPSG:4326').bounds()
-            # else:
-            #
-            #     # reproject CRS bounds
-            #     to_srid = QgsCoordinateReferenceSystem(
-            #         f'EPSG:{instance.group.srid.auth_srid}')
-            #     from_srid = QgsCoordinateReferenceSystem('EPSG:4326')
-            #     ct = QgsCoordinateTransform(
-            #         from_srid, to_srid, QgsCoordinateTransformContext())
-            #     rectangle = ct.transform(to_srid.bounds())
-            #
-            # map_extent = [
-            #     rectangle.xMinimum(),
-            #     rectangle.yMinimum(),
-            #     rectangle.xMaximum(),
-            #     rectangle.yMaximum()
-            # ]
 
         # if use_map_extent_as_init_extent is not flaged set init_map_extent as map_extent
         if not instance.use_map_extent_as_init_extent:

--- a/g3w-admin/qdjango/api/projects/serializers.py
+++ b/g3w-admin/qdjango/api/projects/serializers.py
@@ -384,10 +384,12 @@ class ProjectSerializer(G3WRequestSerializer, serializers.ModelSerializer):
 
                 # Check for empty vector layer
                 if settings.G3W_CLIENT_NOT_SHOW_EMPTY_VECTORLAYER and self.layer_is_empty(layers[layer['id']]):
+                    to_remove_from_layerstree.append((container, layer))
                     return
 
                 # Check if layer is visible for user
                 if self.request and not layer['id'] in view_layer_ids:
+                    to_remove_from_layerstree.append((container, layer))
                     return
 
                 try:


### PR DESCRIPTION
Closes: #462 
