### PR TITLE
Remove `print` command for logging.

### DIFF
--- a/g3w-admin/base/urls.py
+++ b/g3w-admin/base/urls.py
@@ -150,7 +150,6 @@ for app in settings.G3WADMIN_LOCAL_MORE_APPS:
             base_url_app = app
         apiUrlpatterns.append(path('{}/'.format(base_url_app), app_urls))
     except Exception as e:
-        print(e)
         pass
 
 if settings.DEBUG:


### PR DESCRIPTION
Closes: #489 

Remove old and forget `print` exception, used for logging.
