### PR TITLE
Update fixture of `core.mapcontrol` model: add `querybydrawpolygon` and `zoomhistory`

### DIFF
--- a/g3w-admin/client/tests/test_api.py
+++ b/g3w-admin/client/tests/test_api.py
@@ -133,7 +133,8 @@ class ClientApiTest(CoreTestBase):
             'axisinverted': True,
             'extent': [-180.0, -90.0, 180.0, 90.0]
         })
-        self.assertEqual(resp["group"]["mapcontrols"], ['zoomtoextent', 'zoom', 'zoombox', 'query', 'querybbox', 'querybypolygon', 'overview', 'scaleline', 'geolocation', 'streetview', 'nominatim', 'addlayers', 'length', 'area', 'mouseposition', 'scale'])
+        print(resp["group"]["mapcontrols"])
+        self.assertEqual(resp["group"]["mapcontrols"], ['zoom', 'zoombox', 'zoomtoextent', 'query', 'querybbox', 'querybypolygon', 'overview', 'scaleline', 'geolocation', 'streetview', 'nominatim', 'addlayers', 'length', 'area', 'mouseposition', 'scale'])
         self.assertEqual(resp["group"]["header_logo_img"], "logo_img/qgis-logo.png")
         self.assertEqual(resp["group"]["name"], "Gruppo 1")
         self.assertIsNone(resp["group"]["header_logo_link"])

--- a/g3w-admin/core/fixtures/G3WMapControls.json
+++ b/g3w-admin/core/fixtures/G3WMapControls.json
@@ -1,162 +1,182 @@
-[{
-  "model": "core.mapcontrol",
-  "pk": 1,
-  "fields": {
-    "order": 2,
-    "name": "zoom",
-    "description": ""
-  }
+[
+{
+   "model": "core.mapcontrol",
+   "pk": 1,
+   "fields": {
+      "order": 1,
+      "name": "zoom",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 2,
-  "fields": {
-    "order": 3,
-    "name": "zoombox",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 2,
+   "fields": {
+      "order": 2,
+      "name": "zoombox",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 3,
-  "fields": {
-    "order": 4,
-    "name": "query",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 3,
+   "fields": {
+      "order": 4,
+      "name": "query",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 4,
-  "fields": {
-    "order": 8,
-    "name": "scaleline",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 4,
+   "fields": {
+      "order": 10,
+      "name": "scaleline",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 5,
-  "fields": {
-    "order": 7,
-    "name": "overview",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 5,
+   "fields": {
+      "order": 9,
+      "name": "overview",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 6,
-  "fields": {
-    "order": 5,
-    "name": "querybbox",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 6,
+   "fields": {
+      "order": 6,
+      "name": "querybbox",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 7,
-  "fields": {
-    "order": 6,
-    "name": "querybypolygon",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 7,
+   "fields": {
+      "order": 7,
+      "name": "querybypolygon",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 8,
-  "fields": {
-    "order": 1,
-    "name": "zoomtoextent",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 8,
+   "fields": {
+      "order": 5,
+      "name": "zoomtoextent",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 9,
-  "fields": {
-    "order": 9,
-    "name": "geolocation",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 9,
+   "fields": {
+      "order": 11,
+      "name": "geolocation",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 10,
-  "fields": {
-    "order": 10,
-    "name": "streetview",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 10,
+   "fields": {
+      "order": 12,
+      "name": "streetview",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 11,
-  "fields": {
-    "order": 11,
-    "name": "nominatim",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 11,
+   "fields": {
+      "order": 13,
+      "name": "nominatim",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 12,
-  "fields": {
-    "order": 12,
-    "name": "addlayers",
-    "description": "Add kml and GeoJSON overlay layers to map."
-  }
+   "model": "core.mapcontrol",
+   "pk": 12,
+   "fields": {
+      "order": 14,
+      "name": "addlayers",
+      "description": "Add kml and GeoJSON overlay layers to map."
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 13,
-  "fields": {
-    "order": 13,
-    "name": "length",
-    "description": "Measure lenght control."
-  }
+   "model": "core.mapcontrol",
+   "pk": 13,
+   "fields": {
+      "order": 15,
+      "name": "length",
+      "description": "Measure lenght control."
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 14,
-  "fields": {
-    "order": 14,
-    "name": "area",
-    "description": "Measure area control."
-  }
+   "model": "core.mapcontrol",
+   "pk": 14,
+   "fields": {
+      "order": 16,
+      "name": "area",
+      "description": "Measure area control."
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 15,
-  "fields": {
-    "order": 15,
-    "name": "mouseposition",
-    "description": "Cursor position in map unit."
-  }
+   "model": "core.mapcontrol",
+   "pk": 15,
+   "fields": {
+      "order": 17,
+      "name": "mouseposition",
+      "description": "Cursor position in map unit."
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 16,
-  "fields": {
-    "order": 16,
-    "name": "scale",
-    "description": "Map control for show intercative scale map."
-  }
+   "model": "core.mapcontrol",
+   "pk": 16,
+   "fields": {
+      "order": 18,
+      "name": "scale",
+      "description": "Map control for show intercative scale map."
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 17,
-  "fields": {
-    "order": 17,
-    "name": "screenshot",
-    "description": ""
-  }
+   "model": "core.mapcontrol",
+   "pk": 17,
+   "fields": {
+      "order": 19,
+      "name": "screenshot",
+      "description": ""
+   }
 },
 {
-  "model": "core.mapcontrol",
-  "pk": 18,
-  "fields": {
-    "order": 18,
-    "name": "geoscreenshot",
-    "description": ""
-  }
-}]
+   "model": "core.mapcontrol",
+   "pk": 18,
+   "fields": {
+      "order": 20,
+      "name": "geoscreenshot",
+      "description": ""
+   }
+},
+{
+   "model": "core.mapcontrol",
+   "pk": 19,
+   "fields": {
+      "order": 8,
+      "name": "querybydrawpolygon",
+      "description": ""
+   }
+},
+{
+   "model": "core.mapcontrol",
+   "pk": 20,
+   "fields": {
+      "order": 3,
+      "name": "zoomhistory",
+      "description": ""
+   }
+}
+]

--- a/g3w-admin/core/fixtures/G3WMapControls.json
+++ b/g3w-admin/core/fixtures/G3WMapControls.json
@@ -21,7 +21,7 @@
    "model": "core.mapcontrol",
    "pk": 3,
    "fields": {
-      "order": 4,
+      "order": 5,
       "name": "query",
       "description": ""
    }
@@ -66,7 +66,7 @@
    "model": "core.mapcontrol",
    "pk": 8,
    "fields": {
-      "order": 5,
+      "order": 4,
       "name": "zoomtoextent",
       "description": ""
    }


### PR DESCRIPTION
Add two new map-controls, `querybydrawpolygon` and `zoomhistory` as map-controls available:

![Screenshot_20230324_111722](https://user-images.githubusercontent.com/196809/227495094-e1f34f6a-76e2-4aec-8e07-1e29522c7361.png)

Related G3W-CLIENT PRs: 

- https://github.com/g3w-suite/g3w-client/pull/341
- https://github.com/g3w-suite/g3w-client/pull/388

Closes: #486
