### PR TITLE
Manage WMS services without `GetFeatureInfo` request.

### DIFF
--- a/g3w-admin/core/api/views.py
+++ b/g3w-admin/core/api/views.py
@@ -36,6 +36,10 @@ from core.utils.qgisapi import (
     ExpressionLayerError
 )
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class APIExpressionEvalError(APIException):
     status_code = status.HTTP_400_BAD_REQUEST
@@ -251,7 +255,12 @@ class InterfaceOws(G3WAPIView):
 
         # Info formats
         # -----------------------------------
-        self.results.results.update({'info_formats': ows.getOperationByName('GetFeatureInfo').formatOptions})
+        try:
+            self.results.results.update({'info_formats': ows.getOperationByName('GetFeatureInfo').formatOptions})
+        except Exception as e:
+
+            # Case where OWS service doesn't support GetFeatureInfo
+            logger.debug(f'The service {url} doesn\'t support GetFeatureInfo, err: {str(e)}')
 
         # Layers
         # -----------------------------------

--- a/g3w-admin/core/api/views.py
+++ b/g3w-admin/core/api/views.py
@@ -273,7 +273,11 @@ class InterfaceOws(G3WAPIView):
             # Build crs
             crss = []
             for srid in ows[al].crsOptions:
-                crs = QgsCoordinateReferenceSystem(f"EPSG:{srid}")
+                if srid.startswith('EPSG:') or srid.startswith('CRS:'):
+                    crs = QgsCoordinateReferenceSystem()
+                    crs.createFromOgcWmsCrs(srid)
+                else:
+                    crs = QgsCoordinateReferenceSystem(f"EPSG:{srid}")
 
                 if crs.postgisSrid() in settings.G3W_PROJ4_EPSG.keys():
                     proj4 = settings.G3W_PROJ4_EPSG[crs.postgisSrid()]


### PR DESCRIPTION
Inside the `/interface/ows` API REST, added a check and exception handling for WMS services that do not provide `GetFeatureInfo`

Closes: #521 
