### PR TITLE
Fix check locked features on delete editing action

### DIFF
--- a/g3w-admin/editing/api/base/views.py
+++ b/g3w-admin/editing/api/base/views.py
@@ -455,15 +455,17 @@ class BaseEditingVectorOnModelApiView(BaseVectorApiView):
 
             fids = post_layer_data[EDITING_POST_DATA_DELETED]
 
-            # get feature fids from server fids from client.
-            fids = get_layer_fids_from_server_fids([str(id) for id in fids], qgis_layer)
-
             for feature_id in fids:
 
                 # control feature locked
                 if not metadata_layer.lock.checkFeatureLocked(str(feature_id)):
                     raise Exception(self.no_more_lock_feature_msg.format(
                         feature_id, metadata_layer.client_var))
+
+            # get feature fids from server fids from client.
+            fids = get_layer_fids_from_server_fids([str(id) for id in fids], qgis_layer)
+
+            for feature_id in fids:
 
                 # Get feature to delete
                 ex = QgsJsonExporter(qgis_layer)


### PR DESCRIPTION
Move check feature locked on delete feature before to translate feature ID to feature PROVIDER ID.

Closes: #524
