### PR TITLE
Refactor `"qdjango.apps"` logger

### DIFF
--- a/g3w-admin/qdjango/apps.py
+++ b/g3w-admin/qdjango/apps.py
@@ -4,50 +4,59 @@ import glob
 import importlib
 
 from core.utils.general import getAuthPermissionContentType
+
 from django.apps import AppConfig, apps
 from django.dispatch import receiver
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_migrate
+
 from qgis.core import QgsApplication, QgsProject, QgsPathResolver
 from qgis.server import QgsServer, QgsServerSettings, QgsConfigCache
+
 from usersmanage.configs import *
 
 logger = logging.getLogger(__name__)
 logger_qgis_server = logging.getLogger('qgis.server')
 
-if settings.DEBUG:
-    os.environ['QGIS_SERVER_LOG_LEVEL'] = '0'
-    os.environ['QGIS_SERVER_LOG_STDERR'] = '1'
-
 # Custom QGIS Project Cache settings
 USE_CUSTOM_CACHE_INVALIDATOR = getattr(
-    settings, 'G3WADMIN_USE_CUSTOM_CACHE_INVALIDATOR', False)
+    settings,
+    'G3WADMIN_USE_CUSTOM_CACHE_INVALIDATOR',
+    False
+)
+
+if settings.DEBUG:
+    os.environ['QGIS_SERVER_LOG_LEVEL']  = '0'
+    os.environ['QGIS_SERVER_LOG_STDERR'] = '1'
 
 # Setup AUTH DB
 if hasattr(settings, 'QGIS_AUTH_DB_DIR_PATH') and settings.QGIS_AUTH_DB_DIR_PATH:
     os.environ['QGIS_AUTH_DB_DIR_PATH'] = settings.QGIS_AUTH_DB_DIR_PATH
 
 if hasattr(settings, 'QGIS_AUTH_PASSWORD_FILE') and settings.QGIS_AUTH_PASSWORD_FILE:
-    if not os.path.isfile(settings.QGIS_AUTH_PASSWORD_FILE):
+    auth_file = settings.QGIS_AUTH_PASSWORD_FILE
+    if not os.path.isfile(auth_file):
         if not hasattr(settings, 'QGIS_AUTH_PASSWORD'):
             raise ImproperlyConfigured(
-                'QGIS_AUTH_PASSWORD_FILE is set but it does not exist and QGIS_AUTH_PASSWORD is not set: either point QGIS_AUTH_PASSWORD_FILE to an existing file or define a password in QGIS_AUTH_PASSWORD')
+                'QGIS_AUTH_PASSWORD_FILE is set but it does not exist' \
+                'and QGIS_AUTH_PASSWORD is not set: either point' \
+                'QGIS_AUTH_PASSWORD_FILE to an existing file or define' \
+                'a password in QGIS_AUTH_PASSWORD'
+            )
         try:
-            with open(settings.QGIS_AUTH_PASSWORD_FILE, 'w+') as pwd_file:
-                pwd_file.write(settings.QGIS_AUTH_PASSWORD)
-                logger.info('QGIS_AUTH_PASSWORD_FILE created as %s' %
-                            settings.QGIS_AUTH_PASSWORD_FILE)
+            with open(auth_file, 'w+') as file:
+                file.write(settings.QGIS_AUTH_PASSWORD)
+                logger.info('QGIS_AUTH_PASSWORD_FILE created as %s' % auth_file)
         except Exception as ex:
-            raise ImproperlyConfigured('Error creating QGIS_AUTH_PASSWORD_FILE %s: %s' % (
-                settings.QGIS_AUTH_PASSWORD_FILE, ex))
-    os.environ['QGIS_AUTH_PASSWORD_FILE'] = settings.QGIS_AUTH_PASSWORD_FILE
+            raise ImproperlyConfigured('Error creating QGIS_AUTH_PASSWORD_FILE %s: %s' % (auth_file, ex) )
+    os.environ['QGIS_AUTH_PASSWORD_FILE'] = auth_file
 
 
 # QGIS API objects, initialized in init_qgis()
-QGS_APPLICATION = None
+QGS_APPLICATION     = None
 QGS_SERVER_SETTINGS = None
-QGS_SERVER = None
+QGS_SERVER          = None
 
 def get_qgis_log(msg, tag, level):
     """
@@ -66,7 +75,10 @@ def get_qgis_log(msg, tag, level):
     }
 
     # Put QGIS message log into python loggging system
-    logger_qgis_server.log(map_log_level[str(level)], f'[{tag}] - {msg}')
+    logger_qgis_server.log(
+        map_log_level[str(level)],
+        f'[{tag}] - {msg}'
+    )
 
 def init_qgis():
     """QGIS Initialization
@@ -77,12 +89,10 @@ def init_qgis():
 
     global QGS_APPLICATION, QGS_SERVER_SETTINGS, QGS_SERVER
 
-    # create a reference to the QgsApplication
-    # setting the second argument to True enables the GUI, which we do not need to do
-    # since this is a custom application
-    QGS_APPLICATION = QgsApplication([], False)
+    # Create a reference to the QgsApplication
+    QGS_APPLICATION = QgsApplication([], False) # False = disable GUI 
 
-    # load providers
+    # Load providers
     QGS_APPLICATION.initQgis()
 
     if hasattr(settings, 'QGIS_AUTH_PASSWORD') and settings.QGIS_AUTH_PASSWORD:
@@ -90,25 +100,22 @@ def init_qgis():
             raise ImproperlyConfigured('QGIS AuthManager is not enabled')
 
         if not QgsApplication.authManager().setMasterPassword(settings.QGIS_AUTH_PASSWORD, True):
-            raise ImproperlyConfigured(
-                'Error setting QGIS Auth DB master password from settings.QGIS_AUTH_PASSWORD')
+            raise ImproperlyConfigured('Error setting QGIS Auth DB master password from settings.QGIS_AUTH_PASSWORD')
 
-    # Do any environment manipulation here, before we create the server
-    # and the settings are read
+    # Manipulate environment variables here
     os.environ['QGIS_SERVER_IGNORE_BAD_LAYERS'] = '1'
 
+    # Create server from settings 
     QGS_SERVER_SETTINGS = QgsServerSettings()
     QGS_SERVER_SETTINGS.load()
 
-    # Create a singleton server instance, this is not really necessary but it
-    # may be a little faster than creating a new instance every time we handle
-    # a request
+    # Singleton server instance (reused across each request)
     QGS_SERVER = QgsServer()
 
     QGS_APPLICATION.messageLog().messageReceived.connect(get_qgis_log)
 
 
-def remove_project_from_cache(path):
+def remove_project_from_cache(path: str):
     """Removes a project from server's cache
 
     :param path: project path
@@ -116,9 +123,11 @@ def remove_project_from_cache(path):
     """
     QgsConfigCache.instance().removeEntry(path)
     QGS_SERVER.serverInterface().capabilitiesCache().removeCapabilitiesDocument(path)
-    logger.warning(
-        'QGIS Server project removed from cache: %s' % path)
+    logger.warning('QGIS Server project removed from cache: %s' % path)
 
+def formatted_time(mtime: float) -> str:
+    import datetime
+    return datetime.datetime.fromtimestamp(mtime).strftime('%Y-%m-%d %H:%M')
 
 class ProjectCacheInvalidator():
     """Cache manager that checks the project file last modified time and
@@ -143,23 +152,19 @@ class ProjectCacheInvalidator():
             return
 
         mtime = stat_info.st_mtime
-        pid = os.getpid()
+        pid   = os.getpid()
         try:
             if cls.__CACHED_PROJECTS[path] < mtime:
-                logger.debug(
-                    'pid: %s mtime: %s QGIS Server cached project mtime has changed, clearing cache: %s' % (pid, mtime, path))
+                logger.debug('[DELETE] <%s> %s %s from cache' % (pid, formatted_time(mtime), path))
                 remove_project_from_cache(path)
                 del(cls.__CACHED_PROJECTS[path])
             else:
-                logger.debug(
-                    'pid: %s mtime: %s QGIS Server cached project mtime has not changed: %s' % (pid, mtime, path))
+                logger.debug('[HIT] <%s> %s %s from cache' % (pid, formatted_time(mtime), path))
         except KeyError:
-            logger.debug(
-                'pid: %s mtime: %s QGIS Server project added to mtime cache: %s' % (pid, mtime, path))
+            logger.debug('[SET] <%s> %s %s into cache' % (pid, formatted_time(mtime), path))
             cls.__CACHED_PROJECTS[path] = mtime
 
-
-def get_qgs_project(path):
+def get_qgs_project(path: str):
     """Reads and returns a project from the cache, trying to load it
     if it's not there.
 
@@ -196,22 +201,34 @@ def get_qgs_project(path):
                 needs_reload = False
                 for l in list(project.mapLayers().values()):
                     if not l.isValid():
-                        logger.warning('Invalid layer %s found in project %s' % (
-                            l.id(), project.fileName()))
+                        logger.warning(
+                            'Invalid layer %s found in project %s' %
+                            (l.id(), project.fileName())
+                        )
                         if l.dataProvider().name() == 'virtual':
                             needs_reload = True
-                            logger.warning('Invalid virtual layer found in project %s: %s' % (
-                                project.fileName(), l.publicSource()))
+                            logger.warning(
+                                'Invalid virtual layer found in project %s: %s' %
+                                (project.fileName(), l.publicSource())
+                            )
                 if needs_reload:
                     logger.warning('Reload project %s' % project.fileName())
                     QgsProject.instance().read(path)
             except AttributeError:  # Temporary workaround for 3.10.10
                 logger.warning(
-                    'Project reloaded because QgsProject.setInstance() is not available in this QGIS version: %s' % path)
+                    'Project reloaded because QgsProject.setInstance() is not available in this QGIS version: %s' %
+                    path
+                )
                 QgsProject.instance().read(path)
         return QgsProject.instance()
     except Exception as ex:
-        logger.warning('There was an error loading the project from path: %s, this is normally due to unavailable layers. If this is unexpected, please turn on and check server debug logs for further details.\n%s.' % (path, ex))
+        logger.warning(
+            'There was an error loading the project from path: %s,' \
+            ' this is normally due to unavailable layers.' \
+            ' If this is unexpected, please turn on and check server' \
+            ' debug logs for further details.\n%s.' %
+            (path, ex)
+        )
         return None
 
 
@@ -220,17 +237,19 @@ def GiveBaseGrant(sender, **kwargs):
     if isinstance(sender, QdjangoConfig):
         AuthGroup, Permission, ContentType = getAuthPermissionContentType()
         Project = apps.get_app_config('qdjango').get_model('project')
-        Layer = apps.get_app_config('qdjango').get_model('layer')
-        Widget = apps.get_app_config('qdjango').get_model('widget')
+        Layer   = apps.get_app_config('qdjango').get_model('layer')
+        Widget  = apps.get_app_config('qdjango').get_model('widget')
 
-        editor1 = AuthGroup.objects.get(name=G3W_EDITOR1)
+        editor1           = AuthGroup.objects.get(name = G3W_EDITOR1)
         editor1Permission = editor1.permissions.all()
-        editor2 = AuthGroup.objects.get(name=G3W_EDITOR2)
+        editor2           = AuthGroup.objects.get(name = G3W_EDITOR2)
         editor2Permission = editor2.permissions.all()
 
         permissionsToAdd = (
             Permission.objects.get(
-                codename='add_project', content_type=ContentType.objects.get_for_model(Project)),
+                codename     = 'add_project',
+                content_type = ContentType.objects.get_for_model(Project)
+            ),
         )
 
         for perm in permissionsToAdd:
@@ -242,7 +261,9 @@ def GiveBaseGrant(sender, **kwargs):
         # for editor1 and editor2
         permissionsToAdd = (
             Permission.objects.get(
-                codename='add_widget', content_type=ContentType.objects.get_for_model(Widget)),
+                codename     = 'add_widget',
+                content_type = ContentType.objects.get_for_model(Widget)
+            ),
         )
 
         for perm in permissionsToAdd:
@@ -253,10 +274,10 @@ def GiveBaseGrant(sender, **kwargs):
 
 
 class QdjangoConfig(AppConfig):
-    name = 'qdjango'
+    name         = 'qdjango'
     verbose_name = 'QGIS project managment'
-    alias = 'QGIS'
-    icon = 'qdjango/img/qgis-icon32.png'
+    alias        = 'QGIS'
+    icon         = 'qdjango/img/qgis-icon32.png'
 
     def ready(self):
 
@@ -274,27 +295,30 @@ class QdjangoConfig(AppConfig):
             from .models import Project
             from .utils.catalog_provider import catalog_provider
 
-            Catalog.register_catalog_record_provider(catalog_provider,
-                                                     scope=Catalog.SCOPE.GROUP,
-                                                     senders=[Project])
+            Catalog.register_catalog_record_provider(
+                catalog_provider,
+                scope   = Catalog.SCOPE.GROUP,
+                senders = [Project]
+            )
 
         # Set a path resolver to find data in DATASOURCE_PATH
+
         # def datasource_processor(path):
-        #    return path.replace('./', settings.DATASOURCE_PATH if not settings.DATASOURCE_PATH.endswith('/') else (settings.DATASOURCE_PATH + '/'))
+        #    return path.replace(
+        #       './',
+        #       settings.DATASOURCE_PATH if not settings.DATASOURCE_PATH.endswith('/') else (settings.DATASOURCE_PATH + '/')
+        #    )
 
         # QgsPathResolver.setPathPreprocessor(datasource_processor)
 
-        # Load all QGIS server filter plugins, apps can load additional filters
-        # by registering them directly to QGS_SERVER
-        # Load all QGIS server services plugins, apps can load additional services
-        # by registering them directly to QGS_SERVER
+        # Load all QGIS server "filter" and "services" plugins,
+        # apps can load additional filters and services by
+        # registering them directly to QGS_SERVER
         from . import server_filters, server_services
 
-        # Load custom QGIS functions from qdjango/qgis_functions directory
-        functions_folder = os.path.join(
-            os.path.dirname(__file__), 'qgis_functions')
+        # Load custom QGIS functions from "qdjango/qgis_functions" directory
+        functions_folder = os.path.join(os.path.dirname(__file__), 'qgis_functions')
 
         for f in glob.glob(functions_folder + '/*.py'):
             if '__init__.py' not in f:
-                basename = os.path.basename(f)[:-3]
-                importlib.import_module('qdjango.qgis_functions.' + basename)
+                importlib.import_module('qdjango.qgis_functions.' + os.path.basename(f)[:-3])


### PR DESCRIPTION
## List of changes

Reduce verbosity of server logs related to the following option in order to slightly increase readability while debugging:

```py
G3WADMIN_USE_CUSTOM_CACHE_INVALIDATOR = true
```

For example:

```py
logger.debug('pid: %s mtime: %s QGIS Server cached project mtime has changed, clearing cache: %s' % (pid, mtime, path))
```

becomes:

```py
logger.debug('[DELETE] <%s> %s %s from cache' % (pid, formatted_time(mtime), path))
```

## How to test

1. Enable `G3WADMIN_USE_CUSTOM_CACHE_INVALIDATOR` and add `'qdjango.apps'` logger within your local settings:

```py
# g3w-suite-docker/config/g3wsuite/docker_settings.py

G3WADMIN_USE_CUSTOM_CACHE_INVALIDATOR = True

LOGGING = {
  ...
    'loggers': {
        'qdjango.apps': {
            'handlers': ['console'],
            'level': 'DEBUG',
        },
  ...
```

2. follow this steps https://github.com/g3w-suite/g3w-admin/issues/480#issue-1628877535 to start displaying some debug information within the server console
