### PR TITLE
Creating SECRET_KEY file on setup of an existing deployed instance.

### DIFF
--- a/ci_scripts/setup_suite.sh
+++ b/ci_scripts/setup_suite.sh
@@ -88,6 +88,12 @@ else
     rm -rf bower_components
     ln -s "/code/node_modules/@bower_components" bower_components
 
+    # Create SECRET_KEY value file if not exists
+    if [ ! -e ${SECRET_KEY_FILE} ]; then
+    echo "Creating a unique SECRET_KEY file ..."
+    python3 "${DJANGO_DIRECTORY}/manage.py" generate_secret_key_file -o ${SECRET_KEY_FILE}
+    fi
+
     rm -rf ${STATIC_ROOT}
     cd ${DJANGO_DIRECTORY}
     if [[ -z ${G3WSUITE_DEBUG} || ${G3WSUITE_DEBUG} != "True" ]]; then


### PR DESCRIPTION
During the startup of a docker deploy G3W-SUITE instance, if the file containing SECRET_KEY  is not present, authentication system fails. 
To avoid it inside the [setup_suite.sh](https://github.com/g3w-suite/g3w-admin/blob/dev/ci_scripts/setup_suite.sh) a creation for SECRET_KEY file has been added.

Closes: #559 
