### PR TITLE
`api/expression_eval` ARI rest no more `login required`.

### DIFF
--- a/g3w-admin/core/api/permissions.py
+++ b/g3w-admin/core/api/permissions.py
@@ -2,7 +2,6 @@ from django.apps import apps
 from rest_framework.permissions import BasePermission
 from guardian.utils import get_anonymous_user
 from core.models import Group
-from qdjango.models import Project
 
 
 class ProjectPermission(BasePermission):
@@ -15,11 +14,11 @@ class ProjectPermission(BasePermission):
         # get model by type
         func, args, kwargs = request.resolver_match
 
-        if 'project_type' in kwargs:
-            Model = apps.get_app_config(kwargs['project_type']).get_model('project')
-            project = Model.objects.get(pk=kwargs['project_id'])
-        else:
-            project = Project.objects.get(pk=kwargs['project_id'])
+        if 'project_type' not in kwargs:
+            kwargs['project_type'] = 'qdjango'
+
+        Project = apps.get_app_config(kwargs['project_type']).get_model('project')
+        project = Project.objects.get(pk=kwargs['project_id'])
         return request.user.has_perm('{}.view_project'.format(kwargs['project_type']), project) or \
             get_anonymous_user().has_perm('{}.view_project'.format(kwargs['project_type']), project)
 

--- a/g3w-admin/core/api/permissions.py
+++ b/g3w-admin/core/api/permissions.py
@@ -2,6 +2,7 @@ from django.apps import apps
 from rest_framework.permissions import BasePermission
 from guardian.utils import get_anonymous_user
 from core.models import Group
+from qdjango.models import Project
 
 
 class ProjectPermission(BasePermission):
@@ -14,8 +15,11 @@ class ProjectPermission(BasePermission):
         # get model by type
         func, args, kwargs = request.resolver_match
 
-        Project = apps.get_app_config(kwargs['project_type']).get_model('project')
-        project = Project.objects.get(pk=kwargs['project_id'])
+        if 'project_type' in kwargs:
+            Model = apps.get_app_config(kwargs['project_type']).get_model('project')
+            project = Model.objects.get(pk=kwargs['project_id'])
+        else:
+            project = Project.objects.get(pk=kwargs['project_id'])
         return request.user.has_perm('{}.view_project'.format(kwargs['project_type']), project) or \
             get_anonymous_user().has_perm('{}.view_project'.format(kwargs['project_type']), project)
 

--- a/g3w-admin/core/api/views.py
+++ b/g3w-admin/core/api/views.py
@@ -6,6 +6,7 @@ from owslib.wms import WebMapService
 from base.version import get_version
 from .base.views import G3WAPIView
 from core.api.authentication import CsrfExemptSessionAuthentication
+from core.api.permissions import ProjectPermission
 from qdjango.models import Project
 from core.api.base.views import APIException
 from core.utils.geo import get_crs_bbox
@@ -151,6 +152,8 @@ class QgsExpressionLayerContextEvalView(G3WAPIView):
     `qgs_layer_id`: QGIS layer id
 
     """
+
+    permission_classes = (ProjectPermission,)
 
     authentication_classes = (
         CsrfExemptSessionAuthentication,

--- a/g3w-admin/core/apiurls.py
+++ b/g3w-admin/core/apiurls.py
@@ -86,7 +86,7 @@ urlpatterns = [
     #############################################################
     path(
         'api/expression_eval/<int:project_id>/',
-        login_required(QgsExpressionLayerContextEvalView.as_view()),
+        QgsExpressionLayerContextEvalView.as_view(),
         name='layer-expression-eval'
     ),
 


### PR DESCRIPTION
Remove `login_required` decorator from `api/expression_eval` API REST. This PR fix cases where `Anonymous` user can do editing (`EDITING_ANONYMOUS` settings to True) and editing form fields contain QGIS expression to evaluate.
