### PR TITLE
Fix title name group

### DIFF
--- a/g3w-admin/core/api/serializers.py
+++ b/g3w-admin/core/api/serializers.py
@@ -89,10 +89,9 @@ class GroupSerializer(G3WRequestSerializer, serializers.ModelSerializer):
 
         try:
             macrogroup = instance.macrogroups.get(use_title_client=True)
-            ret['name'] = macrogroup.title
+            ret['title'] = macrogroup.title
         except:
-            # change groupData name with title for i18n app
-            ret['name'] = instance.title
+            pass
 
         # add crs:
         crs = QgsCoordinateReferenceSystem(f'EPSG:{self.instance.srid.srid}')
@@ -260,6 +259,7 @@ class GroupSerializer(G3WRequestSerializer, serializers.ModelSerializer):
         fields = (
             'id',
             'name',
+            'title',
             'slug',
             'minscale',
             'maxscale',

--- a/g3w-admin/qdjango/utils/data.py
+++ b/g3w-admin/qdjango/utils/data.py
@@ -657,28 +657,53 @@ class QgisProjectLayer(XmlData):
                         to_ret_node['visibility_expression'] = None
                         visibility_expression = None
 
-                    if element.type() == QgsAttributeEditorElement.AeTypeRelation:
-                        to_ret_node.update({
-                            'nmRelationId': element.nmRelationId()
-                        })
+                    if Qgis.QGIS_VERSION_INT >= 33200:
+                            etype = element.type()
 
-                    if element.type() == QgsAttributeEditorElement.AeTypeContainer:
+                            if isinstance(etype, Qgis.AttributeEditorContainerType):
+                                to_ret_node.update({
+                                    'groupbox': element.isGroupBox(),
+                                    'columncount': element.columnCount(),
+                                    'nodes': build_form_tree_object(element.children())
+                                })
+                            else:
+                                if element.type() == Qgis.AttributeEditorType.Relation:
+                                    to_ret_node.update({
+                                        'nmRelationId': element.nmRelationId()
+                                    })
 
-                        to_ret_node.update({
-                            'groupbox': element.isGroupBox(),
-                            'columncount': element.columnCount(),
-                            'nodes': build_form_tree_object(element.children())
-                        })
+                                if element.type() == Qgis.AttributeEditorType.Field:
+                                    to_ret_node.update({
+                                        'index': element.idx(),
+                                        'field_name': element.name()
+                                    })
+                                    if to_ret_node['name'] in self.aliases:
+                                        to_ret_node.update(
+                                            {'alias': self.aliases[to_ret_node['name']]})
+                                    del (to_ret_node['name'])
+                    else:
+                        if element.type() == QgsAttributeEditorElement.AeTypeRelation:
+                            to_ret_node.update({
+                                'nmRelationId': element.nmRelationId()
+                            })
 
-                    if element.type() == QgsAttributeEditorElement.AeTypeField:
-                        to_ret_node.update({
-                            'index': element.idx(),
-                            'field_name': element.name()
-                        })
-                        if to_ret_node['name'] in self.aliases:
-                            to_ret_node.update(
-                                {'alias': self.aliases[to_ret_node['name']]})
-                        del(to_ret_node['name'])
+                        if element.type() == QgsAttributeEditorElement.AeTypeContainer:
+
+                            to_ret_node.update({
+                                'groupbox': element.isGroupBox(),
+                                'columncount': element.columnCount(),
+                                'nodes': build_form_tree_object(element.children())
+                            })
+
+                        if element.type() == QgsAttributeEditorElement.AeTypeField:
+                            to_ret_node.update({
+                                'index': element.idx(),
+                                'field_name': element.name()
+                            })
+                            if to_ret_node['name'] in self.aliases:
+                                to_ret_node.update(
+                                    {'alias': self.aliases[to_ret_node['name']]})
+                            del(to_ret_node['name'])
 
                     to_ret_form_structure.append(to_ret_node)
                 return to_ret_form_structure


### PR DESCRIPTION
- Set into initconfig API the correct value for group.name and group.title parameters.
- Adapt to new `QgsAttributeEditorContainer` element of QGIS version >= 3.32.


Closes: #
