### PR TITLE
Add generic srs extent, instead of CRS bbox.

### DIFF
--- a/g3w-admin/base/settings/base_geo_settings.py
+++ b/g3w-admin/base/settings/base_geo_settings.py
@@ -34,9 +34,15 @@ TILESTACHE_CONFIG_BASE = {
 # --------------------------------------
 
 G3W_PROJ4_EPSG = {
-  3003: "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl "
-        "+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
-  3004: "+proj=tmerc +lat_0=0 +lon_0=15 +k=0.9996 +x_0=2520000 +y_0=0 +ellps=intl "
-        "+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs +type=crs"
+  3003: {
+    "proj4": "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl "
+             "+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
+    "extent": [0,0,8388608,8388608]
+  },
+  3004: {
+    "proj4": "+proj=tmerc +lat_0=0 +lon_0=15 +k=0.9996 +x_0=2520000 +y_0=0 +ellps=intl "
+                  "+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs +type=crs",
+    "extent": [0,0,8388608,8388608]
+  }
 }
 

--- a/g3w-admin/core/api/serializers.py
+++ b/g3w-admin/core/api/serializers.py
@@ -107,7 +107,8 @@ class GroupSerializer(G3WRequestSerializer, serializers.ModelSerializer):
             'proj4': proj4,
             'geographic': crs.isGeographic(),
             'axisinverted': crs.hasAxisInverted(),
-            'extent': get_crs_bbox(crs)
+            #'extent': get_crs_bbox(crs)
+            'extent': [0,0,8388608,8388608]
         }
 
         # map controls

--- a/g3w-admin/core/api/serializers.py
+++ b/g3w-admin/core/api/serializers.py
@@ -98,17 +98,22 @@ class GroupSerializer(G3WRequestSerializer, serializers.ModelSerializer):
 
         # Patch for Proj4 > 4.9.3 version
         if self.instance.srid.srid in settings.G3W_PROJ4_EPSG.keys():
-            proj4 = settings.G3W_PROJ4_EPSG[self.instance.srid.srid]
+            proj4 = settings.G3W_PROJ4_EPSG[self.instance.srid.srid]['proj4']
+            extent = settings.G3W_PROJ4_EPSG[self.instance.srid.srid]['extent']
+
         else:
             proj4 = crs.toProj4()
+            if crs.postgisSrid() in (4326, 3857):
+                extent = get_crs_bbox(crs)
+            else:
+                extent = [0,0,8388608,8388608]
 
         ret['crs'] = {
             'epsg': crs.postgisSrid(),
             'proj4': proj4,
             'geographic': crs.isGeographic(),
             'axisinverted': crs.hasAxisInverted(),
-            #'extent': get_crs_bbox(crs)
-            'extent': [0,0,8388608,8388608]
+            'extent': extent
         }
 
         # map controls


### PR DESCRIPTION
To ensure that OpenLayers requires the right coordinates on layers xyz for project layers for which caching has been enabled, it is necessary to provide a general extension of srs.

Closes: #571 
