### PR TITLE
Bump version from `(0, 0, 0, 'unstable', 0)` to `(3, 7, 0, 'unstable', 0)`

### DIFF
--- a/g3w-admin/base/__init__.py
+++ b/g3w-admin/base/__init__.py
@@ -13,4 +13,4 @@ except ImportError:
     logger.warning('Celery could not be imported, this might be ok if there are no custom suite modules that require Celery')
 
 
-__version__ = (0, 0, 0, 'unstable', 0)
+__version__ = (3, 7, 0, 'unstable', 0)


### PR DESCRIPTION
## Motivation

https://github.com/g3w-suite/g3w-admin/commit/c6c5238a442f15661e58319c9fc974c1b19d91de breaks our development setup:

```py
# https://github.com/g3w-suite/g3w-suite-docker/blob/f90ce492fcb962969c0eb1b5d21611dadd36025b/config/g3w-suite/settings_docker.py#L8-L15

# Load custom templates and static files from your docker volume (eg. "./config/g3w-suite/overrides/")
# --------------------------------------------
# https://docs.djangoproject.com/en/2.2/howto/overriding-templates/
# https://docs.djangoproject.com/en/2.2/howto/static-files/
# https://docs.djangoproject.com/en/2.2/topics/settings/
if( version >= (3, 5) ):
    settings.TEMPLATES[0]['DIRS'].append(os.path.join(settings.BASE_DIR, '../../templates')) # /code/templates
    settings.STATICFILES_DIRS.append(os.path.join(settings.BASE_DIR, '../../static'))        # /code/static
```

As well as making it harder to locate the current admin version over time (ref: `g3wsdk.info()`).