### PR TITLE
:bug: Fix missing  `: . = ,` in `qdjango-prjtheme-api` url.

### DIFF
--- a/g3w-admin/qdjango/apiurls.py
+++ b/g3w-admin/qdjango/apiurls.py
@@ -298,7 +298,7 @@ urlpatterns = [
         name='qdjango-asgeotiff-api'
     ),
     re_path(
-        r'^api/prjtheme/(?P<project_id>\d+)/(?P<theme_name>[-_\w\d\s]+)/$',
+        r'^api/prjtheme/(?P<project_id>\d+)/(?P<theme_name>[-_\w\d\s:.=,]+)/$',
         QdjangoPrjThemeAPIview.as_view(),
         name='qdjango-prjtheme-api'
     ),

--- a/g3w-admin/qdjango/tests/test_theme.py
+++ b/g3w-admin/qdjango/tests/test_theme.py
@@ -134,6 +134,13 @@ class QdjangoThemeTest(QdjangoTestBase):
         self.assertFalse(jres['result'])
         self.assertEqual(jres['error'], f"Themes are not available for project {self.project.instance.title}")
 
+        # Test theme with special characters: :,.,=
+        response = self._testApiCall('qdjango-prjtheme-api',
+                                     args=[self.project.instance.pk, 'Tav.01: streets, points'])
+        jres = json.loads(response.content)
+        self.assertFalse(jres['result'])
+        self.assertEqual(jres['error'], f"Themes are not available for project {self.project.instance.title}")
+
         # Test view not into project
         response = self._testApiCall('qdjango-prjtheme-api',
                                      args=[self.project_theme316.instance.pk, 'Faketheme'])


### PR DESCRIPTION
Closes: #677
