### PR TITLE
Invalidate cache on filter-layer-by-user saving.

### DIFF
--- a/g3w-admin/qdjango/vector.py
+++ b/g3w-admin/qdjango/vector.py
@@ -507,6 +507,9 @@ class LayerVectorView(QGISLayerVectorViewMixin, BaseVectorApiView):
                 'state': 'created' if created else 'updated'
             })
 
+            # Is necessary invalidate the config project
+            self.layer.project.invalidate_cache(user=request.user)
+
         elif mode == 'apply':
 
             kwargs = _check_url_params_name_fid('apply')
@@ -542,6 +545,8 @@ class LayerVectorView(QGISLayerVectorViewMixin, BaseVectorApiView):
                 user = request.user,
                 **kwargs
             ).delete()
+
+            self.layer.project.invalidate_cache(user=request.user)
 
         # mode='delete'
         else:


### PR DESCRIPTION
Closes: #719

Fix invalidation project cache after save a filter by user.

