### PR TITLE
:bug: Fix session filter feature by selection fo PostgreSql layers

### DIFF
--- a/g3w-admin/qdjango/models/filters.py
+++ b/g3w-admin/qdjango/models/filters.py
@@ -83,14 +83,16 @@ class SessionTokenFilter(models.Model):
             return ""
         else:
 
-            # Check for `postgres` layer
-            if layer.layer_type == 'postgres':
-                pattern = r'\((.*?)\)'
-                fids = re.findall(pattern, stf_layers[0].qgs_expr)[0].split(',')
+            qgs_expr = stf_layers[0].qgs_expr
+            ids = re.findall(r'\((.*?)\)', stf_layers[0].qgs_expr)
+
+            # Check for `postgres` layer and qgis expression template '$id IN (...)'
+            if layer.layer_type == 'postgres' and len(ids) == 1:
+                fids = ids[0].split(',')
                 fids = get_layer_fids_from_server_fids(map(str, fids), layer.qgis_layer)
                 return f"$id IN ({','.join(map(str, fids))})"
             else:
-                return stf_layers[0].qgs_expr
+                return qgs_expr
 
     class Meta:
         app_label = 'qdjango'

--- a/g3w-admin/qdjango/tests/test_api.py
+++ b/g3w-admin/qdjango/tests/test_api.py
@@ -1137,7 +1137,7 @@ class TestQdjangoLayersAPI(QdjangoTestBase):
 
         self.assertEqual(resp['data'], {
                 'layer': cities.qgs_layer_id,
-                'qgs_expression': '$id NOT IN (9,8,6,0)',
+                'qgs_expression': '$id NOT IN (6,8,9,0)',
                 'name': 'filter 1 layer cities',
                 'fid': 1,
                 'state': 'created'
@@ -1154,7 +1154,7 @@ class TestQdjangoLayersAPI(QdjangoTestBase):
 
         self.assertEqual(resp['data'], {
             'layer': cities.qgs_layer_id,
-            'qgs_expression': '$id NOT IN (9,8,6,0)',
+            'qgs_expression': '$id NOT IN (6,8,9,0)',
             'name': 'filter 1 layer cities',
             'fid': 1,
             'state': 'updated'
@@ -1180,7 +1180,7 @@ class TestQdjangoLayersAPI(QdjangoTestBase):
 
         self.assertEqual(resp['data'], {
             'layer': cities.qgs_layer_id,
-            'qgs_expression': '$id NOT IN (9,8,6,0) AND $id NOT IN (2,1)',
+            'qgs_expression': '$id NOT IN (6,8,9,0) AND $id NOT IN (1,2)',
             'name': 'filter 2 layer cities',
             'fid': 2,
             'state': 'created'
@@ -1213,7 +1213,7 @@ class TestQdjangoLayersAPI(QdjangoTestBase):
 
         # Check inside the current fitlertoken
         token = sf.token
-        self.assertEqual(sf.stf_layers.all()[0].qgs_expr, '$id NOT IN (9,8,6,0)')
+        self.assertEqual(sf.stf_layers.all()[0].qgs_expr, '$id NOT IN (6,8,9,0)')
 
         # Delete fitler token and apply again to check for new fitler token value
         SessionTokenFilter.objects.all().delete()
@@ -1226,7 +1226,7 @@ class TestQdjangoLayersAPI(QdjangoTestBase):
                                             }, logout=False).content)
         sf = SessionTokenFilter.objects.all()[0]
         self.assertFalse(token == sf.token)
-        self.assertEqual(sf.stf_layers.all()[0].qgs_expr, '$id NOT IN (9,8,6,0)')
+        self.assertEqual(sf.stf_layers.all()[0].qgs_expr, '$id NOT IN (6,8,9,0)')
 
         # Filter for layer check /api/config REST API:
         resp = json.loads(self._testApiCall('group-project-map-config',

--- a/g3w-admin/qdjango/vector.py
+++ b/g3w-admin/qdjango/vector.py
@@ -417,18 +417,6 @@ class LayerVectorView(QGISLayerVectorViewMixin, BaseVectorApiView):
         fidsin = request_data.get('fidsin')
         fidsout = request_data.get('fidsout')
 
-        # Get layer fids from server fids
-        if fidsin:
-            fidsin = get_layer_fids_from_server_fids([str(fid) for fid in fidsin.split(',')],
-                                                     self.metadata_layer.qgis_layer)
-            fidsin.reverse()
-            fidsin = ",".join(map(str, fidsin))
-        if fidsout:
-            fidsout = get_layer_fids_from_server_fids([str(fid) for fid in fidsout.split(',')],
-                                                     self.metadata_layer.qgis_layer)
-            fidsout.reverse()
-            fidsout = ",".join(map(str, fidsout))
-
         token_data = {}
 
         def _create_qgs_expr(s, fidsin=None, fidsout=None):


### PR DESCRIPTION
Closes: #752

Refactoring of #753, in particular this refactoring move the translation between QGIS server feature ID (_sfid_) with QGIS layer feature ID (_lfid_).

In a multi processing deploy (i.e docker compose deploy by gunicorn) different processes can send different _sfid_ so the translation to _lfid_ must be done at runtime _sessionfiltertoken_ application.

