### PR TITLE
Patch for QgsXmlUltils.

### DIFF
--- a/g3w-admin/qplotly/vendor/DataPlotly/core/plot_settings.py
+++ b/g3w-admin/qplotly/vendor/DataPlotly/core/plot_settings.py
@@ -207,6 +207,10 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
         self.source_layer_id = res.get('source_layer_id', None)
         self.data_defined_properties.loadVariant(res.get('dynamic_properties', None), PlotSettings.DYNAMIC_PROPERTIES)
 
+        # With QGIS > 3.28 the QgsXmlutils.readVariant method has a new behavior for Qstring tipe parameters
+        if self.layout['title'] == None:
+            self.layout['title'] = ''
+
         return True
 
     def write_to_project(self, document: QDomDocument):

--- a/g3w-admin/qplotly/vendor/DataPlotly/core/plot_settings.py
+++ b/g3w-admin/qplotly/vendor/DataPlotly/core/plot_settings.py
@@ -207,7 +207,7 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
         self.source_layer_id = res.get('source_layer_id', None)
         self.data_defined_properties.loadVariant(res.get('dynamic_properties', None), PlotSettings.DYNAMIC_PROPERTIES)
 
-        # With QGIS > 3.28 the QgsXmlutils.readVariant method has a new behavior for Qstring tipe parameters
+        # With QGIS > 3.28 the QgsXmlutils.readVariant method has a new behavior for Qstring type parameters
         if self.layout['title'] == None:
             self.layout['title'] = ''
 


### PR DESCRIPTION
With QGIS > 3.28 the `QgsXmlutils.readVariant` method has a new behavior for Qstring type parameters, instead ofr return an empty string return None.
