### PR TITLE
'suggest' parameter in combination with 'fformatter' parameter

### DIFF
--- a/g3w-admin/core/api/base/views.py
+++ b/g3w-admin/core/api/base/views.py
@@ -584,12 +584,27 @@ class BaseVectorApiView(G3WAPIView):
                                 QVariant(),
                                 u
                             )
-                            values.append([json.loads(QgsJsonUtils.encodeValue(u)), fvalue])
+
+                            to_append = True
+
+                            # 'suggest' (get/post) parameter used inside the QGIS SuggestFilterBackend
+                            # must be applied to the formatted value (fvalue) because the result of formatted value
+                            # can come also from QgsExression
+                            if 'suggest' in self.request_data:
+
+                                # Replace suggest file with r_pvalue if pvalue == suggest field
+                                s_field, s_value =  self.request_data.get('suggest').split('|')
+                                to_append = False
+                                if s_field == pvalue and str(s_value).lower() in str(fvalue).lower():
+                                    to_append = True
+
+                            if to_append:
+                                values.append([json.loads(QgsJsonUtils.encodeValue(u)), fvalue])
                 except Exception as e:
                     logger.error(f'Response vector widget unique: {e}')
                     continue
 
-            # sort values
+            # Sort values
             if ('fformatter' in self.request_data
                 and 'ordering' in self.request_data
                 and self.request_data['fformatter'] in self.request_data['ordering']):

--- a/g3w-admin/core/api/base/views.py
+++ b/g3w-admin/core/api/base/views.py
@@ -590,10 +590,10 @@ class BaseVectorApiView(G3WAPIView):
                             # 'suggest' (get/post) parameter used inside the QGIS SuggestFilterBackend
                             # must be applied to the formatted value (fvalue) because the result of formatted value
                             # can also derive from QgsExression(s).
-                            if 'suggest' in self.request_data:
+                            if 'suggest' in self.request_data and 'fformatter' in self.request_data:
 
                                 # Replace suggest file with r_pvalue if pvalue == suggest field
-                                s_field, s_value =  self.request_data.get('suggest').split('|')
+                                s_field, s_value = self.request_data.get('suggest').split('|')
                                 to_append = False
                                 if s_field == pvalue and str(s_value).lower() in str(fvalue).lower():
                                     to_append = True

--- a/g3w-admin/core/api/base/views.py
+++ b/g3w-admin/core/api/base/views.py
@@ -589,7 +589,7 @@ class BaseVectorApiView(G3WAPIView):
 
                             # 'suggest' (get/post) parameter used inside the QGIS SuggestFilterBackend
                             # must be applied to the formatted value (fvalue) because the result of formatted value
-                            # can come also from QgsExression
+                            # can also derive from QgsExression(s).
                             if 'suggest' in self.request_data:
 
                                 # Replace suggest file with r_pvalue if pvalue == suggest field

--- a/g3w-admin/core/api/filters.py
+++ b/g3w-admin/core/api/filters.py
@@ -231,11 +231,7 @@ class SuggestFilterBackend(BaseFilterBackend):
         qgis_layer = metadata_layer.qgis_layer
 
         # Try to get param from GET
-        suggest_value = request.query_params.get('suggest')
-
-        if not suggest_value:
-            # Try to get from POST
-            suggest_value = request.data.get('suggest')
+        suggest_value = request.query_params.get('suggest', request.data.get('suggest'))
 
         if suggest_value:
 

--- a/g3w-admin/qdjango/static/qdjango/js/widget.js
+++ b/g3w-admin/qdjango/static/qdjango/js/widget.js
@@ -378,7 +378,7 @@ ga.Qdjango.widgetEditor = {
 
     var widgetSelect = $('<select class="form-control" name="widget_type"></select>')
     $.each(options, function (k, i) {
-      widgetSelect.append('<option value="' + k + '">' + i + "</option>")
+        widgetSelect.append('<option value="' + k + '">' + i + "</option>")
     })
 
     // add widget types
@@ -410,6 +410,13 @@ ga.Qdjango.widgetEditor = {
       if (_.indexOf(['DateTime'], ga.Qdjango.localVars.layer_edittypes[$(this).val()].widgetv2type) != -1) {
         // Append 'DatetimBox' to widget selectbox
         widgetSelect.append('<option value="datetimebox">' + that.datetime_widgettype.datetimebox + '</option>');
+      }
+
+      // Remove `AutoCompleteBox` from widget type list
+      if (ga.Qdjango.localVars.layer_edittypes[$(this).val()].widgetv2type == 'ValueRelation') {
+        widgetSelect.find("option[value=\"autocompletebox\"]").hide();
+      } else {
+        widgetSelect.find("option[value=\"autocompletebox\"]").show();
       }
 
     })


### PR DESCRIPTION
Closes: #810

With this PR now is possible apply `suggest` parameter for `/vector/api/data` API REST in combination with 'fformatter' parameter. 

The `suggest` parameter will contain the `fformatter` field name.
