### PR TITLE
Replace `wait-for-it` with `pg_isready` within `setup_suite.sh`

### DIFF
--- a/ci_scripts/setup_suite.sh
+++ b/ci_scripts/setup_suite.sh
@@ -44,8 +44,11 @@ if [ ! -e ${SETUP_DONE_FILE} ]; then
     ls ${PROJECTS_DIR} || mkdir ${PROJECTS_DIR}
     ls ${DATASOURCE_PATH} || mkdir ${DATASOURCE_PATH}
 
-    wait-for-it -h ${G3WSUITE_POSTGRES_HOST:-postgis} -p ${G3WSUITE_POSTGRES_PORT:-5432} -t 60
-
+    until pg_isready -h ${G3WSUITE_POSTGRES_HOST:-postgis} -p ${G3WSUITE_POSTGRES_PORT:-5432}; do
+      echo "wait 30s until is ready"
+      sleep 30;
+    done
+    
     pushd .
     cd ${DJANGO_DIRECTORY}/core/static
     rm -rf bower_components
@@ -81,7 +84,10 @@ if [ ! -e ${SETUP_DONE_FILE} ]; then
 else
     echo "Setup was already done, skipping ..."
     # Wait for postgis
-    wait-for-it -h ${G3WSUITE_POSTGRES_HOST:-postgis} -p ${G3WSUITE_POSTGRES_PORT:-5432} -t 60
+    until pg_isready -h ${G3WSUITE_POSTGRES_HOST:-postgis} -p ${G3WSUITE_POSTGRES_PORT:-5432}; do
+      echo "wait 30s until is ready"
+      sleep 30;
+    done
 
     # Restore on restart ln -s for bower_component
     cd ${DJANGO_DIRECTORY}/core/static


### PR DESCRIPTION
## Before

```sh
# Wait for postgis
wait-for-it -h ${G3WSUITE_POSTGRES_HOST:-postgis} -p ${G3WSUITE_POSTGRES_PORT:-5432} -t 60
```

## After

```sh
# Wait for postgis
until pg_isready -h ${G3WSUITE_POSTGRES_HOST:-postgis} -p ${G3WSUITE_POSTGRES_PORT:-5432}; do
  echo "wait 30s until is ready"
  sleep 30;
done
```

Related to: https://github.com/g3w-suite/g3w-suite-docker/pull/120