### PR TITLE
Eval expression response json

### DIFF
--- a/g3w-admin/core/api/views.py
+++ b/g3w-admin/core/api/views.py
@@ -206,7 +206,8 @@ class QgsExpressionLayerContextEvalView(G3WAPIView):
         except ExpressionLayerError as ex:
             raise APIExpressionLayerError(str(ex))
 
-        return Response(result)
+        self.results.results.update({'value': result})
+        return Response(self.results.results)
 
 
 class InterfaceOws(G3WAPIView):

--- a/g3w-admin/core/tests/test_qgisapi.py
+++ b/g3w-admin/core/tests/test_qgisapi.py
@@ -411,7 +411,7 @@ class LayerExpressionEval(CoreTestBase):
         url = reverse('layer-expression-eval',
                       args=[project.pk])
 
-        self._expression_evaluate(url, {'result': True, 'value': 1}, 1)
+        self._expression_evaluate(url, '1', {'result': True, 'value': 1})
 
         form_data = {
             'bbox': [-92.28845, 13.7392, -88.23725, 17.783133],

--- a/g3w-admin/core/tests/test_qgisapi.py
+++ b/g3w-admin/core/tests/test_qgisapi.py
@@ -433,8 +433,8 @@ class LayerExpressionEval(CoreTestBase):
             'type': 'Feature'}
 
         self._expression_evaluate(
-            url, 'current_value(\'CAPITAL\')', "GUATEMALA", form_data, world.qgs_layer_id)
+            url, 'current_value(\'CAPITAL\')', {'result': True, 'value': "GUATEMALA"}, form_data, world.qgs_layer_id)
 
         # Test QVariant NULL result
         self._expression_evaluate(
-            url, 'current_value(\'CAPITALA\')', "", form_data, world.qgs_layer_id)
+            url, 'current_value(\'CAPITALA\')', {'result': True, 'value': ""}, form_data, world.qgs_layer_id)

--- a/g3w-admin/core/tests/test_qgisapi.py
+++ b/g3w-admin/core/tests/test_qgisapi.py
@@ -411,7 +411,7 @@ class LayerExpressionEval(CoreTestBase):
         url = reverse('layer-expression-eval',
                       args=[project.pk])
 
-        self._expression_evaluate(url, '1', 1)
+        self._expression_evaluate(url, {'result': True, 'value': 1}, 1)
 
         form_data = {
             'bbox': [-92.28845, 13.7392, -88.23725, 17.783133],


### PR DESCRIPTION
Refactoring of response of `/api/expression_eval/<int:project_id>/` with a standard G3W-SUITE API Json response, i.e.:

From a response body like this
```
'GUATEMALA'
```
To a Json response body like this:
```
{'result': True, 'value': "GUATEMALA"}
````