### PR TITLE
ALLOWED_HOSTS must be an array

### DIFF
--- a/g3w-admin/base/settings/local_settings_example.py
+++ b/g3w-admin/base/settings/local_settings_example.py
@@ -69,7 +69,7 @@ ORS_MAX_RANGES = 6
 ORS_MAX_LOCATIONS = 2
 
 
-ALLOWED_HOSTS = "*"
+ALLOWED_HOSTS = ["*"]
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
ALLOWED_HOSTS must be an array, as specified in [docs](https://docs.djangoproject.com/en/5.0/ref/settings/#allowed-hosts).
Current string value "*" causes error in manage commands.
```python
$ python3 manage.py makemigrations
django.core.exceptions.ImproperlyConfigured: The ALLOWED_HOSTS setting must be a list or a tuple.
```