### PR TITLE
Use QGIS API to convert layer's datasource to dictionary

### DIFF
--- a/g3w-admin/qdjango/api/projects/serializers.py
+++ b/g3w-admin/qdjango/api/projects/serializers.py
@@ -19,7 +19,7 @@ from qdjango.utils.data import QGIS_LAYER_TYPE_NO_GEOM
 from qdjango.utils.models import get_capabilities4layer, get_view_layer_ids
 from qdjango.signals import load_qdjango_widget_layer
 from qdjango.apps import get_qgs_project
-from qdjango.utils.structure import QdjangoMetaLayer, datasourcearcgis2dict
+from qdjango.utils.structure import QdjangoMetaLayer, datasource2dict
 from qdjango.utils.session import reset_filtertoken
 from qdjango.api.layers.serializers import FilterLayerSavedSerializer
 from core.utils.structure import mapLayerAttributes
@@ -844,7 +844,7 @@ class LayerSerializer(G3WRequestSerializer, serializers.ModelSerializer):
             if instance.layer_type == Layer.TYPES.wms:
                 datasource_wms = QueryDict(instance.datasource)
             else:
-                datasource_wms = datasourcearcgis2dict(instance.datasource)
+                datasource_wms = datasource2dict(instance.datasource, instance.layer_type)
 
             if ('username' not in ret['source'] or 'password' not in ret['source']) and 'type=xyz' \
                     not in instance.datasource:

--- a/g3w-admin/qdjango/tests/test_utils.py
+++ b/g3w-admin/qdjango/tests/test_utils.py
@@ -18,7 +18,7 @@ from django.conf import settings
 from qdjango.models import Project, Layer, Widget
 from qdjango.utils.data import QgisProject, QgisPgConnection, QgisProjectSettingsWMS
 from qdjango.utils.exceptions import QgisProjectLayerException, QgisProjectException
-from qdjango.utils.structure import get_schema_table, datasource2dict, datasourcearcgis2dict
+from qdjango.utils.structure import get_schema_table, datasource2dict
 from qdjango.utils.models import get_widgets4layer, comparedbdatasource, get_capabilities4layer
 from qdjango.utils.qgis import explode_expression
 from qdjango.templatetags.qdjango_tags import is_geom_type_gpx_compatible
@@ -402,10 +402,8 @@ class QgisProjectTest(TestCase):
         self.assertEqual(res['password'], 'password')
         self.assertEqual(res['port'], '5432')
 
-    def test_dataSourceArcGisToDict(self):
-
-        res = datasourcearcgis2dict(
-            'crs=\'EPSG:4326\' format=\'PNG24\' layer=\'2\' url=\'https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Specialty/ESRI_StateCityHighway_USA/MapServer\'')
+        res = datasource2dict(
+            'crs=\'EPSG:4326\' format=\'PNG24\' layer=\'2\' url=\'https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Specialty/ESRI_StateCityHighway_USA/MapServer\'', "arcgismapserver")
         self.assertEqual(res['crs'], 'EPSG:4326')
         self.assertEqual(res['format'], 'PNG24')
         self.assertEqual(res['layer'], '2')

--- a/g3w-admin/qdjango/tests/test_utils.py
+++ b/g3w-admin/qdjango/tests/test_utils.py
@@ -357,7 +357,7 @@ class QgisProjectTest(TestCase):
 
     def test_dataSourceToDict(self):
 
-        res = datasource2dict("dbname='data_testing' host=web-gis.postgres.database.azure.com port=5432 sslmode=require user='testing@webgis' password='#\\\'$%?@^&rX43#/' srid=4326 type=Point checkPrimaryKeyUnicity='1' table=\"public\".\"net_datacenter_hyperscale_v0.1_ch_190321\" (geom) sql=")
+        res = datasource2dict("dbname='data_testing' host=web-gis.postgres.database.azure.com port=5432 sslmode=require user='testing@webgis' password='#\\\'$%?@^&rX43#/' srid=4326 type=Point checkPrimaryKeyUnicity='1' table=\"public\".\"net_datacenter_hyperscale_v0.1_ch_190321\" (geom) sql=", "postgres")
 
         self.assertEqual(res['checkPrimaryKeyUnicity'], '1')
         self.assertEqual(res['dbname'], 'data_testing')
@@ -369,7 +369,7 @@ class QgisProjectTest(TestCase):
         self.assertEqual(
             res['table'], "\"public\".\"net_datacenter_hyperscale_v0.1_ch_190321\"")
 
-        res = datasource2dict('dbname=\'data_testing\' user=\'xxx\' password=\'xxx\' host=localhost port=5432 sslmode=disable key=\'id\' srid=4326 type=LineStringZ checkPrimaryKeyUnicity=\'0\' table="centurylink"."Fbr Chain: HY.OS.001.0001..212.000.31..16 B -- PLTN" (geom) sql=')
+        res = datasource2dict('dbname=\'data_testing\' user=\'xxx\' password=\'xxx\' host=localhost port=5432 sslmode=disable key=\'id\' srid=4326 type=LineStringZ checkPrimaryKeyUnicity=\'0\' table="centurylink"."Fbr Chain: HY.OS.001.0001..212.000.31..16 B -- PLTN" (geom) sql=', "postgres")
         self.assertEqual(
             res['table'], "\"centurylink\".\"Fbr Chain: HY.OS.001.0001..212.000.31..16 B -- PLTN\"")
         self.assertEqual(res['checkPrimaryKeyUnicity'], '0')
@@ -382,7 +382,7 @@ class QgisProjectTest(TestCase):
 
         # for Postgis Raster
         res = datasource2dict(
-            "PG:  dbname='geo_demo' host=localhost user=postgres password=postgres port=5432 mode=2 schema='raster' column='rast' table='nasa_density_population' ")
+            "PG:  dbname='geo_demo' host=localhost user=postgres password=postgres port=5432 mode=2 schema='raster' column='rast' table='nasa_density_population' ", "postgres")
         self.assertEqual(res['dbname'], 'geo_demo')
         self.assertEqual(res['table'], 'nasa_density_population')
         self.assertEqual(res['host'], 'localhost')
@@ -394,7 +394,7 @@ class QgisProjectTest(TestCase):
 
         # Issue with finland customer
         res = datasource2dict(
-            'dbname=\'my_db\' host=my.host.name port=5432 user=\'user\' password=\'password\' sslmode=disable key=\'identifier\' checkPrimaryKeyUnicity=\'0\' table="akaa_gk20"."spatial_plan_regulation"')
+            'dbname=\'my_db\' host=my.host.name port=5432 user=\'user\' password=\'password\' sslmode=disable key=\'identifier\' checkPrimaryKeyUnicity=\'0\' table="akaa_gk20"."spatial_plan_regulation"', "postgres")
         self.assertEqual(res['dbname'], 'my_db')
         self.assertEqual(res['table'], '"akaa_gk20"."spatial_plan_regulation"')
         self.assertEqual(res['host'], 'my.host.name')

--- a/g3w-admin/qdjango/tests/test_utils_form_expressions.py
+++ b/g3w-admin/qdjango/tests/test_utils_form_expressions.py
@@ -18,7 +18,6 @@ from django.conf import settings
 from qdjango.models import Project, Layer, Widget
 from qdjango.utils.data import QgisProject, QgisPgConnection, QgisProjectSettingsWMS
 from qdjango.utils.exceptions import QgisProjectLayerException, QgisProjectException
-from qdjango.utils.structure import get_schema_table, datasource2dict, datasourcearcgis2dict
 from qdjango.utils.models import get_widgets4layer, comparedbdatasource, get_capabilities4layer
 from qdjango.templatetags.qdjango_tags import is_geom_type_gpx_compatible
 from collections import OrderedDict

--- a/g3w-admin/qdjango/utils/data.py
+++ b/g3w-admin/qdjango/utils/data.py
@@ -13,7 +13,8 @@ from django.utils.translation import gettext_lazy as _
 from lxml import etree
 
 from qgis.core import (
-    QgsProject, QgsMapLayer,
+    QgsProject,
+    QgsMapLayer,
     QgsUnitTypes,
     QgsProjectVersion,
     QgsWkbTypes,
@@ -253,14 +254,14 @@ class QgisProjectLayer(XmlData):
                 if self.datasource.startswith('PG:'):
 
                     # add whitespace to datasource string for re findall
-                    dts = datasource2dict(self.datasource + ' ')
+                    dts = datasource2dict(self.datasource + ' ', self.qgs_layer.providerType())
                     name = re.sub('["\']', "", dts['table'].split('.')[-1])
                 else:
                     name = os.path.splitext(
                         os.path.basename(self.datasource))[0]
         elif self.layerType == Layer.TYPES.postgres or self.layerType == Layer.TYPES.spatialite:
             try:
-                dts = datasource2dict(self.datasource)
+                dts = datasource2dict(self.datasource, self.qgs_layer.providerType())
                 name = dts['table'].split('.')[-1].replace("\"", "")
             except:
 
@@ -1857,7 +1858,7 @@ class QgisProjectSettingsWMS(XmlData):
         :param tag: str xml tag name
         :return: search string
         :rtype: str
-        """
+        """setData
         return '{{{0}}}{1}'.format(self._NS['xlink'], tag)
 
     def _getBBOXLayer(self, layerTree):

--- a/g3w-admin/qdjango/utils/models.py
+++ b/g3w-admin/qdjango/utils/models.py
@@ -32,8 +32,8 @@ def comparedbdatasource(ds1, ds2, layer_type='postgres'):
 
     try:
         # split ds
-        ds1 = datasource2dict(ds1)
-        ds2 = datasource2dict(ds2)
+        ds1 = datasource2dict(ds1, layer_type)
+        ds2 = datasource2dict(ds2, layer_type)
 
 
         # compare only dbname and table if host is not present like for SQlite db:
@@ -61,7 +61,7 @@ def get_widgets4layer(layer):
     # for postgis layer
     if layer.layer_type == 'postgres':
         try:
-            ds = datasource2dict(layer.datasource)
+            ds = datasource2dict(layer.datasource, layer.layer_type)
         except:
 
             # For very complex QueryLayer

--- a/g3w-admin/qdjango/utils/structure.py
+++ b/g3w-admin/qdjango/utils/structure.py
@@ -112,18 +112,6 @@ def datasource2dict(datasource: str, provider: str) -> dict[str, str]:
     return parts
 
 
-def datasourcearcgis2dict(datasource: str) -> dict[str, str]:
-    """
-    Read a ArcGisMapServer datasource string and put data in a python dict
-
-    :param datasource: qgis project arcgis layer datasource
-    :return: dict with datasource params
-    :rtype: dict
-    """
-
-    return {k: str(v) for k, v in QgsProviderRegistry.instance().decodeUri("arcgismapserver", datasource).items()}
-
-
 class QdjangoMetaLayer(CoreMetaLayer):
     """
     Metalayer used for belonging layers group activations/deactivations image map by client tree toc

--- a/g3w-admin/qdjango/utils/structure.py
+++ b/g3w-admin/qdjango/utils/structure.py
@@ -79,37 +79,37 @@ def qgsdatasourceuri2dict(datasource: str) -> dict:
     return toret
 
 
-def datasource2dict(datasource):
+def datasource2dict(datasource: str, provider: str) -> dict[str, str]:
     """
     Read a DB datasource string and put data in a python dict
 
     :param datasource: qgis project datasource
+    :param provider: data provider type (key)
     :return: dict with datasource params
     :rtype: dict
     """
 
-    datasourceDict = {}
+    # first try with the provider specific method
+    parts = QgsProviderRegistry.instance().decodeUri(provider, datasource)
+    if parts:
+        return {k: str(v) for k, v in parts.items()}
 
-    # before get sql
-    try:
-        datasource, sql = datasource.split('sql=')
-    except:
-        sql = None
+    # data provider does not support decodeUri(), we need to process it manually
+    parts = {}
+    ds_uri = QgsDataSourceUri(datasource)
+    for k in ds_uri.parameterKeys():
+        value = ds_uri[k]
+        if value:
+            parts[k] = str(value)
 
-    keys = re.findall(r'([A-z][A-z0-9-_]+)=[\'"]?[#$^?+=!*()\'-/@%&\w\."]+[\'"]?', datasource)
-    for k in keys:
-        try:
-            datasourceDict[k] = re.findall(r'%s=([^"\'][#$^?+=!*()\'-/@%%&\w\.]+|\d)' % k, datasource)[0]
-        except:
-            # If I reincarnate as a human, I'll choose to be a farmer.
-            datasourceDict[k] = re.findall(r'%s=((?:["\'](?:(?:[^\"\']|\\\')+)["\'])(?:\.["\'](?:(?:[^\"\']|\\\')+)["\'])?)(?:\s|$)' % k, datasource)[0].strip('\'')
+        # special handling for "sql" parameter
+        if k == "sql":
+            if value:
+                parts[k] = '{}'.format(unicode2ascii(value))
+            else:
+                parts[k] = ""
 
-    # add sql
-    if sql:
-        datasourceDict['sql'] = '{}'.format(unicode2ascii(sql))
-    else:
-        datasourceDict['sql'] = ''
-    return datasourceDict
+    return parts
 
 
 def datasourcearcgis2dict(datasource: str) -> dict[str, str]:

--- a/g3w-admin/qdjango/utils/structure.py
+++ b/g3w-admin/qdjango/utils/structure.py
@@ -9,7 +9,7 @@ from urllib.parse import urlsplit, parse_qs
 from core.utils.projects import CoreMetaLayer
 from core.utils import unicode2ascii
 from .exceptions import QgisProjectLayerException
-from qgis.core import QgsDataSourceUri
+from qgis.core import QgsDataSourceUri, QgsProviderRegistry
 
 import requests
 
@@ -112,7 +112,7 @@ def datasource2dict(datasource):
     return datasourceDict
 
 
-def datasourcearcgis2dict(datasource):
+def datasourcearcgis2dict(datasource: str) -> dict[str, str]:
     """
     Read a ArcGisMapServer datasource string and put data in a python dict
 
@@ -121,16 +121,7 @@ def datasourcearcgis2dict(datasource):
     :rtype: dict
     """
 
-    datasourcedict = {}
-
-    keys = re.findall(r'([A-z][A-z0-9-_]+)=[\'"]?[#$^?+=!*()\'-/@%&\w\."]+[\'"]?', datasource)
-    for k in keys:
-        try:
-            datasourcedict[k] = re.findall(r'{}=[\'"]([#$:_^?+=!*()\'-/@%&\w\."]+)[\'"]'.format(k), datasource)[0]
-        except:
-            pass
-
-    return datasourcedict
+    return {k: str(v) for k, v in QgsProviderRegistry.instance().decodeUri("arcgismapserver", datasource).items()}
 
 
 class QdjangoMetaLayer(CoreMetaLayer):

--- a/g3w-admin/qdjango/utils/structure.py
+++ b/g3w-admin/qdjango/utils/structure.py
@@ -9,7 +9,7 @@ from urllib.parse import urlsplit, parse_qs
 from core.utils.projects import CoreMetaLayer
 from core.utils import unicode2ascii
 from .exceptions import QgisProjectLayerException
-from qgis.core import QgsDataSourceUri, QgsProviderRegistry
+from qgis.core import Qgis, QgsDataSourceUri, QgsProviderRegistry
 
 import requests
 
@@ -89,10 +89,14 @@ def datasource2dict(datasource: str, provider: str) -> dict[str, str]:
     :rtype: dict
     """
 
-    # first try with the provider specific method
-    parts = QgsProviderRegistry.instance().decodeUri(provider, datasource)
-    if parts:
-        return {k: str(v) for k, v in parts.items()}
+    # TODO: teprorarily safeguard with version check as QGIS < 3.42.1 and QGIS < 3.40.5
+    # have small bug in PostgreSQL data provider decodeUri(). For more details
+    # see https://github.com/qgis/QGIS/pull/60703
+    if Qgis.QGIS_VERSION_INT >= 34201 or Qgis.QGIS_VERSION_INT >= 34005:
+        # first try with the provider specific method
+        parts = QgsProviderRegistry.instance().decodeUri(provider, datasource)
+        if parts:
+            return {k: str(v) for k, v in parts.items()}
 
     # data provider does not support decodeUri(), we need to process it manually
     parts = {}

--- a/g3w-admin/qplotly/utils/models.py
+++ b/g3w-admin/qplotly/utils/models.py
@@ -31,7 +31,7 @@ def get_qplotlywidgets4layer(layer):
     # for postgis layer
     if layer.layer_type == 'postgres':
         try:
-            ds = datasource2dict(layer.datasource)
+            ds = datasource2dict(layer.datasource, layer.layer_type)
         except:
 
             # For very complex QueryLayer


### PR DESCRIPTION
Use QGIS API to convert data source  string to Python dictionary.

Instead of relying on regular expressions, try to parse datasource string using provider-specific `decodeUri()` method and if corresponding provider does not support it - fallback to use `QgsDataSourceUri` class. Also removed `datasourcearcgis2dict()` function as its functionality should be covered by updated `datasource2dict()`.

Note that for QGIS <= 3.43 and QGIS <= 3.40.5 we are using generic approach with `QgsDatasourceUri ` because of the minor bug in PostgreSQL data provider which was fixed with https://github.com/qgis/QGIS/pull/60703 and backported to 3.40/3.42 branches. Later this version check can be removed.

Fixes #276.
