### PR TITLE
Fix "Translatable fields" string being untranslatable

### DIFF
--- a/g3w-admin/core/forms.py
+++ b/g3w-admin/core/forms.py
@@ -57,7 +57,7 @@ class GroupForm(TranslationModelForm, FileFormMixin, G3WFormMixin, G3WRequestFor
                                         ),
                                         Div(
                                             HTML(
-                                                f"<p><b>{_('Translatable fields')}</b>: <span class='translate translatable_fields'></span></p>"),
+                                                "<p><b>{}</b>: <span class='translate translatable_fields'></span></p>".format(_('Translatable fields'))),
                                             'name',
                                             Field('title', css_class='translate'),
                                             Field('description', css_class='wys5 translate', style="width:100%;"),
@@ -237,7 +237,7 @@ class GeneralSuiteDataForm(TranslationModelForm, FileFormMixin, ModelForm):
                             css_class='box-header with-border'
                         ),
                         Div(
-                            HTML(f"<p><b>{_('Translatable fields')}</b>: <span class='translate translatable_fields'></span></p>"),
+                            HTML("<p><b>{}</b>: <span class='translate translatable_fields'></span></p>".format(_('Translatable fields'))),
                             Field('title', css_class='translate'),
                             Field('sub_title', css_class='translate'),
                             Field('home_description', css_class='wys5 translate', style="width:100%;"),
@@ -427,7 +427,7 @@ class MacroGroupForm(TranslationModelForm, FileFormMixin, G3WFormMixin, ModelFor
                                         ),
                                         Div(
                                             HTML(
-                                                f"<p><b>{_('Translatable fields')}</b>: <span class='translate translatable_fields'></span></p>"),
+                                                "<p><b>{}</b>: <span class='translate translatable_fields'></span></p>".format(_('Translatable fields'))),
                                             'name',
                                             Field('title', css_class='translate'),
                                             HTML(_(

--- a/g3w-admin/qdjango/forms/projects.py
+++ b/g3w-admin/qdjango/forms/projects.py
@@ -245,7 +245,7 @@ class QdjangoProjectForm(TranslationModelForm, QdjangoProjectFormMixin, G3WFormM
                         ),
                         Div(
                             HTML(
-                                f"<p><b>{_('Translatable fields')}</b>: <span class='translate translatable_fields'></span></p>"
+                                "<p><b>{}</b>: <span class='translate translatable_fields'></span></p>".format(_('Translatable fields'))
                             ),
                             'qgis_file',
                             'qgis_file-uploads',


### PR DESCRIPTION
Adding the `gettext` function inside f-string placeholders is not supported. Injecting the values as format placeholders solves the issue. Also learned this myself the hard way.

See #1149
