### PR TITLE
Do not show the subtitle `None` when the macrogroup does not have a name (yet)

### DIFF
--- a/g3w-admin/core/templates/core/macrogroup_form.html
+++ b/g3w-admin/core/templates/core/macrogroup_form.html
@@ -8,7 +8,10 @@
 {% block page_header %}
 <h1>
     {% trans 'Macro Group' %}
+
+    {% if form.instance.name %}
     <small>{{ form.instance.name }}</small>
+    {% endif %}
 </h1>
 {% endblock %}
 


### PR DESCRIPTION
If one is adding a new macro group, the name is still None. In other cases it can also have an empty value.

In such cases, we should not print anything in the template, otherwise we see "None" as a subtitle.

Closes: #1151

To the maintainers: we could have had the `if` statement inside the `<small />` tag, but now we save a few bytes on the wire. Saw it was used in other places in the codebase. Happy to accomodate if you don't like this approach.

| before | after |
|-|-|
| ![image](https://github.com/user-attachments/assets/3ceb9e30-71da-40a9-9775-c7e6ef17224c) | ![image](https://github.com/user-attachments/assets/e223b46f-ea85-4ea0-b068-7df2036d25f7) |
