### PR TITLE
Make the "System user groups" subheader translatable and fix a typo there

### DIFF
--- a/g3w-admin/usersmanage/templates/usersmanage/user_form.html
+++ b/g3w-admin/usersmanage/templates/usersmanage/user_form.html
@@ -83,7 +83,7 @@
 {% block page_header %}
 <h1>
     {% trans 'System users' %}
-    <small>Stystem users list and property</small>
+    <small>{% trans 'System users list and property' %}</small>
 </h1>
 {% endblock %}
 

--- a/g3w-admin/usersmanage/templates/usersmanage/user_group_form.html
+++ b/g3w-admin/usersmanage/templates/usersmanage/user_group_form.html
@@ -54,7 +54,7 @@
 {% block page_header %}
 <h1>
     {% trans 'System user groups' %}
-    <small>Stystem users list and property</small>
+    <small>{% trans 'System users list and property' %}</small>
 </h1>
 {% endblock %}
 


### PR DESCRIPTION
Allows translations in different languages and fixes a typo. There is no particular issue to relate to, but I hope the change is clear enough.