### PR TITLE
Make footer fully translatable

### DIFF
--- a/g3w-admin/templates/base.html
+++ b/g3w-admin/templates/base.html
@@ -226,11 +226,16 @@ scratch. This page gets rid of all links and provides the needed markup only.
         <!-- To the right -->
         <div class="pull-right hidden-xs">
         {% block footer-right %}
-          <strong>G3W-SUITE {% trans 'Version' %} {{ VERSION }}</strong>: administration GIS application.
+          {% blocktrans trimmed with version=VERSION %}
+            <strong>G3W-SUITE Version {{ version }}</strong>:
+            administration GIS application.
+          {% endblocktrans %}
         {% endblock %}
         </div>
         <!-- Default to the left -->
-        <strong>Copyright &copy; 2015 - {{ today.year }} <a href="http://www.gis3w.it">GIS3W</a>.</strong> All rights reserved.
+        {% blocktrans trimmed with year=today.year %}
+          <strong>Copyright &copy; 2015 - {{ year }} <a href="http://www.gis3w.it">GIS3W</a>.</strong> All rights reserved.
+        {% endblocktrans %}
         {% endif %}
       </footer>
       {% include 'include/sidebar_right.html' %}


### PR DESCRIPTION
Currently the footer translates only subsections of the strings, if any.

The more proper way is to wrap the text in django's awesome `blocktrans` tags which allows to support LTR and RTL languages too.

Related to https://github.com/g3w-suite/g3w-admin/issues/1149

| before | after |
|-|-|
| ![image](https://github.com/user-attachments/assets/52060c5e-6227-4318-8f06-591764030e6a) | ![image](https://github.com/user-attachments/assets/348a4718-64fe-4dc3-a740-73925fe4f4ea) | 

