### PR TITLE
Make UTF compatible symbol in the creative commons license file

### DIFF
--- a/g3w-admin/qdjango/tests/data/geodata/Creative_Commons_Legal_Code.txt
+++ b/g3w-admin/qdjango/tests/data/geodata/Creative_Commons_Legal_Code.txt
@@ -73,4 +73,4 @@ UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS T
 
     Creative Commons may be contacted at http://creativecommons.org/.
 
-« Back to Commons Deed
+Â« Back to Commons Deed


### PR DESCRIPTION
Unfortunately the file was not a valid UTF8 file.
```
$ iconv -f UTF-8 ./g3w-admin/qdjango/tests/data/geodata/Creative_Commons_Legal_Code.txt -o /dev/null
iconv: illegal input sequence at position 18643
```

Now it is.

Closes: #
