### PR TITLE
Make the "permanently delete" label clickable to toggle the checkbox

### DIFF
--- a/g3w-admin/core/static/js/g3wadmin/widget.js
+++ b/g3w-admin/core/static/js/g3wadmin/widget.js
@@ -169,8 +169,10 @@ _.extend(g3wadmin.widget, {
             body = gettext('Are you sure to ' + action + ' this Item')+'?';
             if (action === 'deactivate') {
                 body += '<br/><br/>' +
+                    '<label>' +
                     '<input type="checkbox" value="1" name="permanent_delete" /> ' + 
-                    gettext('Permanently delete');
+                    gettext('Permanently delete') +
+                    '</label>';
             }
             body += (_.isUndefined(preMessage) ? '' : preMessage)
             const modal = ga.ui.buildDefaultModal({


### PR DESCRIPTION
There are certain UI/UX expectations that clicking on labels will trigger the input being labelled. 

![image](https://github.com/user-attachments/assets/aa8279eb-c47e-4843-a87d-f4ac6afccb5a)

Make this expectations and life much easier.
