### PR TITLE
Fix acl fields by user for vector/api/data

### DIFF
--- a/g3w-admin/core/api/base/views.py
+++ b/g3w-admin/core/api/base/views.py
@@ -469,6 +469,13 @@ class BaseVectorApiView(G3WAPIView):
         # Prepare arguments for the get feature call
         kwargs = {}
 
+        # Get visible fields for user
+        visiblefields = None
+        if self.request.user:
+            visiblefields = self.layer.visible_fields_for_user(self.request.user)
+            #if len(visiblefields) != len(vector_params['fields']):
+                #pass
+
         # Apply filter backends, store original subset string
         original_subset_string = self.metadata_layer.qgis_layer.subsetString()
         if hasattr(self, 'filter_backends'):
@@ -725,6 +732,8 @@ class BaseVectorApiView(G3WAPIView):
                 f = feature_collection['features'][i]
                 f['id'] = fids_map[f['id']]
 
+                if visiblefields:
+                    f['properties'] = {k: f['properties'][k] for k in f['properties'] if k in visiblefields}
             api_vector_data = {
                 'data': feature_collection,
                 'count': count_qgis_features(self.metadata_layer.qgis_layer, qgis_feature_request, **kwargs),

--- a/g3w-admin/qdjango/tests/test_column_acl.py
+++ b/g3w-admin/qdjango/tests/test_column_acl.py
@@ -316,8 +316,8 @@ class TestColumnAcl(QdjangoTestBase):
         #self.assertIsNone(record['AREA'])
         #self.assertIsNone(record['SOURCETHM'])
 
-        self.assertIsFalse('AREA' in record)
-        self.assertIsFalse('SOURCETHM' in record)
+        self.assertFalse('AREA' in record)
+        self.assertFalse('SOURCETHM' in record)
 
         # Test for /api/vector/config
         response = self._testApiCallAdmin01(

--- a/g3w-admin/qdjango/tests/test_column_acl.py
+++ b/g3w-admin/qdjango/tests/test_column_acl.py
@@ -313,8 +313,11 @@ class TestColumnAcl(QdjangoTestBase):
 
         # Check that excluded attributes are None
         record = resp['vector']['data']['features'][0]['properties']
-        self.assertIsNone(record['AREA'])
-        self.assertIsNone(record['SOURCETHM'])
+        #self.assertIsNone(record['AREA'])
+        #self.assertIsNone(record['SOURCETHM'])
+
+        self.assertIsFalse('AREA' in record)
+        self.assertIsFalse('SOURCETHM' in record)
 
         # Test for /api/vector/config
         response = self._testApiCallAdmin01(


### PR DESCRIPTION
Fix: remove the 'property' filtered per user
