### PR TITLE
Invalidate project cache on user update

### DIFF
--- a/g3w-admin/qdjango/models/projects.py
+++ b/g3w-admin/qdjango/models/projects.py
@@ -647,16 +647,13 @@ class Project(G3WProjectMixins, G3WACLModelMixins, TimeStampedModel):
 
         try:
 
-            users = User.objects.all() if user == None else [user]
-
             # Invalidate project cache
             pre_keys = (
                 f"{settings.QDJANGO_PRJ_CACHE_KEY}{self.group.slug}_{'qdjango'}_{self.pk}",
                 f"{settings.QDJANGO_PRJ_CACHE_KEY}{self.group.pk}_{'qdjango'}_{self.pk}"
             )
 
-            # Invalidate every cache for every user
-            users = User.objects.all()
+            users = User.objects.all() if user == None else [user]
             for user in users:
                 for pre_key in pre_keys:
                     d = cache.delete(f"{pre_key}_{str(user.pk)}")

--- a/g3w-admin/qdjango/utils/cache.py
+++ b/g3w-admin/qdjango/utils/cache.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+""""
+.. note:: This program is free software; you can redistribute it and/or modify
+    it under the terms of the Mozilla Public License 2.0.
+
+"""
+
+__author__ = 'lorenzetti@gis3w.it'
+__date__ = '2025-09-26 14:40:12'
+__copyright__ = 'Copyright Gis3w'
+
+from guardian.shortcuts import get_objects_for_user
+from qdjango.models import Project
+
+
+def invalidate_user_projects_cache(user):
+    """
+    Invalidate cache for all projects related to a user.
+
+    :param user: Django User instance whose project caches need to be invalidated
+    :type user: django.contrib.auth.models.User
+    """
+
+    # Get every project where user has view permission
+    projects = get_objects_for_user(user, 'qdjango.view_project', Project)
+
+    for project in projects:
+        project.invalidate_cache(user=user)  

--- a/g3w-admin/usersmanage/receivers.py
+++ b/g3w-admin/usersmanage/receivers.py
@@ -15,7 +15,15 @@ from django.dispatch import receiver
 from django_registration.signals import user_registered
 from django.template.loader import render_to_string
 from django.contrib.sites.shortcuts import get_current_site
-from usersmanage.models import Userbackend, USER_BACKEND_DEFAULT, Group as AuthGroup, Userdata
+from django.db.models.signals import post_save
+from qdjango.utils.cache import invalidate_user_projects_cache
+from usersmanage.models import (
+    Userbackend, 
+    USER_BACKEND_DEFAULT, 
+    Group as AuthGroup, 
+    Userdata, 
+    User
+)
 from usersmanage.configs import G3W_VIEWER1
 from usersmanage.signals import after_save_user_form
 import logging
@@ -106,3 +114,11 @@ def send_email_to_user(sender, **kwargs):
     user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL, fail_silently=True)
 
 
+@receiver(post_save, sender=User)
+def invalidate_projects_cache(sender, instance, **kwargs):
+    """
+    Invalidate projects cache on user save
+    """
+
+    if hasattr(settings, 'QDJANGO_PRJ_CACHE') and settings.QDJANGO_PRJ_CACHE:
+        invalidate_user_projects_cache(instance)

--- a/g3w-admin/usersmanage/receivers.py
+++ b/g3w-admin/usersmanage/receivers.py
@@ -119,6 +119,8 @@ def invalidate_projects_cache(sender, instance, **kwargs):
     """
     Invalidate projects cache on user save
     """
-
     if hasattr(settings, 'QDJANGO_PRJ_CACHE') and settings.QDJANGO_PRJ_CACHE:
-        invalidate_user_projects_cache(instance)
+        try:
+            invalidate_user_projects_cache(instance)
+        except:
+            pass


### PR DESCRIPTION
Fixing of the project api/config caching response on update of a user, this fix the issue that happen in example when a user is had to a user group that just have grant on projects.
