### PR TITLE
Fix layout arguments in ActiveEditingLayerForm to include 'style' conditionally

### DIFF
--- a/g3w-admin/editing/forms.py
+++ b/g3w-admin/editing/forms.py
@@ -137,9 +137,10 @@ class ActiveEditingLayerForm(ActiveEditingMixin, G3WRequestFormMixin, G3WProject
         # Check if layer ha geometry or not
         if self.layer.geometrytype != 'NoGeometry':
             layout_args.append('scale')
-            layout_args.append('style')
+            
 
         layout_args += [
+            'style',
             Field('add_user_field', css_class='select2', style="width:100%;"),
             Field('edit_user_field', css_class='select2', style="width:100%;"),
             Field('add_user_group_field', css_class='select2', style="width:100%;"),


### PR DESCRIPTION
Closes: #1234 

<img width="680" height="350" alt="Screenshot_20251024_085726" src="https://github.com/user-attachments/assets/1e19c9f0-8165-495a-9493-816cb0d1fa5f" />
