### PR TITLE
Enhance ProjectSerializer to include current theme detection in QGIS project

### DIFF
--- a/g3w-admin/qdjango/api/projects/serializers.py
+++ b/g3w-admin/qdjango/api/projects/serializers.py
@@ -47,7 +47,9 @@ from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,
     QgsCoordinateTransformContext,
-    QgsExpression
+    QgsExpression, 
+    QgsLayerTreeModel, 
+    QgsMapThemeCollection
 )
 from qgis.server import QgsServerProjectUtils
 from qgis.PyQt.QtCore import QVariant, QDate, QDateTime, Qt
@@ -274,11 +276,19 @@ class ProjectSerializer(G3WRequestSerializer, serializers.ModelSerializer):
         # Check for QGIS project themes
         # -----------------------------
         map_themes = qgs_project.mapThemeCollection().mapThemes()
+        
+        # Check for current theme active
+        # Alessandro Pasotti (elpaso) snippet
+        ltr = qgs_project.layerTreeRoot()
+        model = QgsLayerTreeModel(ltr)
+
+        cur_theme = QgsMapThemeCollection.createThemeFromCurrentState( ltr, model )
 
         for map_theme in map_themes:
             theme = {
                 'theme': map_theme,
-                'styles': {}
+                'styles': {},
+                'default': cur_theme == qgs_project.mapThemeCollection().mapThemeState(map_theme)
             }
 
             for r in qgs_project.mapThemeCollection().mapThemeState(map_theme).layerRecords():

--- a/g3w-admin/qdjango/tests/test_theme.py
+++ b/g3w-admin/qdjango/tests/test_theme.py
@@ -100,21 +100,24 @@ class QdjangoThemeTest(QdjangoTestBase):
                     "styles": {
                         "countries_3857_4f885888_b0df_4f87_88ed_17c907315fad": "predefinito",
                         "cities10000eu_3857_728999c2_0883_4627_8df2_25224f71e3ea": "predefinito"
-                    }
+                    },
+                    'default': True
                 },
                 {
                     "theme": "View2",
                     "styles": {
                         "countries_3857_4f885888_b0df_4f87_88ed_17c907315fad": "predefinito",
                         "cities10000eu_3857_728999c2_0883_4627_8df2_25224f71e3ea": "style_red_square"
-                    }
+                    },
+                    'default': False
                 },
                 {
                     "theme": "View3",
                     "styles": {
                         "countries_3857_4f885888_b0df_4f87_88ed_17c907315fad": "predefinito",
                         "cities10000eu_3857_728999c2_0883_4627_8df2_25224f71e3ea": "style_red_square"
-                    }
+                    },
+                    'default': False
                 }
             ],
             "custom": []


### PR DESCRIPTION
Thanks to @elpaso now is possible to know what  is the active them ad webgis bootstrap

