### PR TITLE
Fix validation and validation message for scale limits in scaleviscon…

### DIFF
--- a/ci_scripts/Dockerfile.deps
+++ b/ci_scripts/Dockerfile.deps
@@ -23,7 +23,7 @@ RUN apt-get update && apt install -y \
     postgresql-client
 
 # PyQGIS latest version
-RUN curl -sS https://download.qgis.org/downloads/qgis-archive-keyring.gpg > /etc/apt/keyrings/qgis-archive-keyring.gpg && \
+RUN curl -L -sS https://download.qgis.org/downloads/qgis-archive-keyring.gpg > /etc/apt/keyrings/qgis-archive-keyring.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu noble main" | \
     tee /etc/apt/sources.list.d/qgis.list && \
     apt-get update && apt-get install -y python3-qgis qgis-server

--- a/ci_scripts/Dockerfile.ltr.deps
+++ b/ci_scripts/Dockerfile.ltr.deps
@@ -23,7 +23,7 @@ RUN apt-get update && apt install -y \
     postgresql-client
 
 # PyQGIS
-RUN curl -sS https://download.qgis.org/downloads/qgis-archive-keyring.gpg > /etc/apt/keyrings/qgis-archive-keyring.gpg && \
+RUN curl -L -sS https://download.qgis.org/downloads/qgis-archive-keyring.gpg > /etc/apt/keyrings/qgis-archive-keyring.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu-ltr noble main" | \
     tee /etc/apt/sources.list.d/qgis.list && \
     apt-get update && apt-get install -y python3-qgis qgis-server

--- a/g3w-admin/qdjango/static/qdjango/js/data-widget-scalevisconstraintManagerList.js
+++ b/g3w-admin/qdjango/static/qdjango/js/data-widget-scalevisconstraintManagerList.js
@@ -153,7 +153,7 @@ export async function scalevisconstraintManagerList($datatable, $item, refresh) 
             ${ '' == dt.user && '' == dt.group        ? `<h4 class="badge bg-red">${gettext("You must select a 'group' or a 'user'!")}</h4>`: '' }
             ${ '' != dt.user && '' != dt.group        ? `<h4 class="badge bg-red">${gettext("You cannot select both a 'group' and a 'user': they are mutually exclusive!")}</h4>`: '' }
             ${ '' == dt.minscale || '' == dt.maxscale ? `<h4 class="badge bg-red">${gettext("The 'maxscale' and/or 'minscale' fields cannot be empty!")}</h4>` : '' }
-            ${ dt.minscale < dt.maxscale ? `<h4 class="badge bg-red">${gettext("The 'maxscale' can not be less than the 'minscale'!")}</h4>` : '' }
+            ${ dt.minscale > dt.maxscale ? `<h4 class="badge bg-red">${gettext("The 'minscale' can not be greater than the 'maxscale'!")}</h4>` : '' }
           `);
 
           if (!form.$form.find(".form-errors").children().length) {


### PR DESCRIPTION
…… (#1270)

* Fix validation and validation message for scale limits in scalevisconstraintManagerList.js

Updated the condition for displaying the error message related to scale limits. The message now correctly indicates that the 'minscale' cannot be greater than the 'maxscale', improving clarity and accuracy in user feedback.

* Fix curl command in Dockerfile to use -L flag for QGIS keyring download

(cherry picked from commit 9888bcc9707950b94724a5d226131542d07e3512)

Closes: #
