### PR TITLE
New store path for media

### DIFF
--- a/g3w-admin/client/urls.py
+++ b/g3w-admin/client/urls.py
@@ -42,10 +42,19 @@ urlpatterns = [
     #############################################################
     # Media reading upload
     #############################################################
+
+    # Just left for backward compatibility
     re_path(
         r'^{}/(?P<project_type>[-_\w\d]+)/(?P<layer_id>[0-9]+)/(?P<file_name>[\(\)"\'-_. \w\d]+)'.format(USER_MEDIA_PREFIX),
         user_media_view,
         name='user-media'
+    ),
+
+    # 20025-12-19: new route with layer_md5_source to avoid problems on change original datasource
+    re_path(
+        r'^{}/(?P<project_type>[-_\w\d]+)/(?P<layer_md5_source>[\w\d]+)/(?P<file_name>[\(\)"\'-_. \w\d]+)'.format(USER_MEDIA_PREFIX),
+        user_media_view,
+        name='user-media-md5'
     ),
 
     path(

--- a/g3w-admin/client/urls.py
+++ b/g3w-admin/client/urls.py
@@ -45,16 +45,9 @@ urlpatterns = [
 
     # Just left for backward compatibility
     re_path(
-        r'^{}/(?P<project_type>[-_\w\d]+)/(?P<layer_id>[0-9]+)/(?P<file_name>[\(\)"\'-_. \w\d]+)'.format(USER_MEDIA_PREFIX),
+        r'^{}/(?P<project_type>[-_\w\d]+)/(?P<ds_layer_id>[-_\w\d]+)/(?P<file_name>[\(\)"\'-_. \w\d]+)'.format(USER_MEDIA_PREFIX),
         user_media_view,
         name='user-media'
-    ),
-
-    # 20025-12-19: new route with layer_md5_source to avoid problems on change original datasource
-    re_path(
-        r'^{}/(?P<project_type>[-_\w\d]+)/(?P<layer_md5_source>[\w\d]+)/(?P<file_name>[\(\)"\'-_. \w\d]+)'.format(USER_MEDIA_PREFIX),
-        user_media_view,
-        name='user-media-md5'
     ),
 
     path(

--- a/g3w-admin/client/views.py
+++ b/g3w-admin/client/views.py
@@ -241,13 +241,13 @@ def user_media_view(request, project_type, ds_layer_id, file_name, *args, **kwar
     # get model by project_type
     try:
         Layer = apps.get_app_config(project_type).get_model('layer')
-        layer = Layer.objects.get(pk=layer_id)
-    except Layer.DoesNotExist:
+        layer = Layer.objects.get(pk=ds_layer_id)
+    except Exception:
         layer = None
 
 
     # check permission
-    return USERMEDIAHANDLER_CLASSES[project_type](layer=layer, file_name=file_name).send_file()
+    return USERMEDIAHANDLER_CLASSES[project_type](layer=layer, file_name=file_name, ds_md5=ds_layer_id).send_file()
 
 
 def credits(request, * args, **kwargs):

--- a/g3w-admin/client/views.py
+++ b/g3w-admin/client/views.py
@@ -228,19 +228,22 @@ class ClientView(TemplateView):
         return response
 
 
-def user_media_view(request, project_type, layer_id, file_name, *args, **kwargs):
+def user_media_view(request, project_type, ds_layer_id, file_name, *args, **kwargs):
     """
     View to return media checking user project permissions
     :param request: Django request object.
     :param project_type: G3W-USITE map project, default 'qdjango'.
-    :param layer_id: Django model Layer pk value.
+    :param ds_layer_id: Django model Layer pk value or md5 key.
     :param file_name: File name to render.
     :return: HttpRensponse or a HttpResponseForbidden instance.
     """
 
     # get model by project_type
-    Layer = apps.get_app_config(project_type).get_model('layer')
-    layer = Layer.objects.get(pk=layer_id)
+    try:
+        Layer = apps.get_app_config(project_type).get_model('layer')
+        layer = Layer.objects.get(pk=layer_id)
+    except Layer.DoesNotExist:
+        layer = None
 
 
     # check permission

--- a/g3w-admin/core/utils/db.py
+++ b/g3w-admin/core/utils/db.py
@@ -53,7 +53,11 @@ def build_dango_connection_name(datasource):
     :return: string
     """
     usingmd5 = hashlib.md5()
-    usingmd5.update(datasource.encode('utf-8'))
+    # Convert to bytes if it's a string, otherwise use as-is
+    if isinstance(datasource, str):
+        usingmd5.update(datasource.encode('utf-8'))
+    else:
+        usingmd5.update(datasource)
     return usingmd5.hexdigest()
 
 

--- a/g3w-admin/core/utils/vector.py
+++ b/g3w-admin/core/utils/vector.py
@@ -220,6 +220,7 @@ class BaseUserMediaHandler(object):
 
     def send_file(self):
         """ Send current media saved """
+        
         if self.layer:
             self.set_layer_md5_source()
             file_path = '{}/{}'.format(self.get_path_to_save(), self.file_name)

--- a/g3w-admin/core/utils/vector.py
+++ b/g3w-admin/core/utils/vector.py
@@ -100,7 +100,7 @@ class BaseUserMediaHandler(object):
         # 2025-12-19: use layer_md5_source to avoid porblems on change original datasource
         return reverse('user-media', kwargs={
                                 'project_type': self.type,
-                                'layer_id': self.layer.pk,
+                                'ds_layer_id': self.layer_md5_source,
                                 'file_name': file_name
                                 })
 

--- a/g3w-admin/core/utils/vector.py
+++ b/g3w-admin/core/utils/vector.py
@@ -25,7 +25,8 @@ class BaseUserMediaHandler(object):
 
         return f"{settings.MEDIA_ROOT}{property.replace(settings.MEDIA_URL, '')}"
 
-    def __init__(self, file_name=None, layer=None, metadata_layer=None, feature=None, request=None):
+    def __init__(self, file_name=None, layer=None, metadata_layer=None, feature=None, request=None, ds_md5=None):
+        """ Initialize class with parameters """
 
         self.file_name = file_name
 
@@ -43,6 +44,9 @@ class BaseUserMediaHandler(object):
         self.feature = feature
 
         self.request = request
+
+        # Md5 of layer datasource
+        self.ds_md5 = ds_md5
 
 
     def set_layer_md5_source(self):
@@ -69,6 +73,7 @@ class BaseUserMediaHandler(object):
 
     def get_path_to_save(self):
         """ Get and build local path to save media """
+
         return '{}{}/{}'.format(settings.USER_MEDIA_ROOT, self.type, self.layer_md5_source)
 
     def get_domain(self):
@@ -92,6 +97,7 @@ class BaseUserMediaHandler(object):
     def _new_path(self, file_name):
         """ Build new path to save media file """
 
+        # 2025-12-19: use layer_md5_source to avoid porblems on change original datasource
         return reverse('user-media', kwargs={
                                 'project_type': self.type,
                                 'layer_id': self.layer.pk,
@@ -214,8 +220,13 @@ class BaseUserMediaHandler(object):
 
     def send_file(self):
         """ Send current media saved """
-        self.set_layer_md5_source()
-        file_path = '{}/{}'.format(self.get_path_to_save(), self.file_name)
+        if self.layer:
+            self.set_layer_md5_source()
+            file_path = '{}/{}'.format(self.get_path_to_save(), self.file_name)
+        else:
+
+            # Case layer not found, try to search create path by self_ds_md5
+            file_path = f'{settings.USER_MEDIA_ROOT}{self.type}/{self.ds_md5}/{self.file_name}'
         return send_file(self.file_name, file_path_mime(file_path), file_path, False)
 
 

--- a/g3w-admin/editing/tests/test_api.py
+++ b/g3w-admin/editing/tests/test_api.py
@@ -2376,3 +2376,81 @@ class ConstraintsApiTests(ConstraintsTestsBase):
         url_layer = reverse('editing-api-info-layer', args=[9999999])
         response = client.get(url_layer, {}, format='json')
         self.assertEqual(response.status_code, 400)
+
+    @override_settings(G3WFILE_FORM_UPLOAD_FORMATS=['jpg', 'png', 'pdf'])
+    def test_upload_file_view(self):
+        """Test UploadFileView for file upload"""
+        from io import BytesIO
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        client = APIClient()
+        
+        # Test without authentication (should work due to csrf_exempt)
+        url = reverse('editing-upload')
+        
+        # Test 1: No file uploaded
+        response = client.post(url, {}, format='multipart')
+        self.assertEqual(response.status_code, 500)
+        self.assertIn('No FILES are uploaded', response.content.decode())
+        
+        # Test 2: Upload valid file with authentication
+        self.assertTrue(client.login(
+            username=self.test_user_admin1.username, 
+            password=self.test_user_admin1.username))
+        
+        # Create a simple test image
+        image_content = BytesIO(b'fake_image_content')
+        test_file = SimpleUploadedFile(
+            name='test_image.jpg',
+            content=image_content.read(),
+            content_type='image/jpeg'
+        )
+        
+        response = client.post(url, {'file': test_file}, format='multipart')
+        self.assertEqual(response.status_code, 200)
+        jcontent = json.loads(response.content)
+        
+        self.assertTrue(jcontent['result'])
+        self.assertIn('data', jcontent)
+        self.assertIn('value', jcontent['data'])
+        self.assertIn('mime_type', jcontent['data'])
+        self.assertIn('test_image.jpg', jcontent['data']['value'])
+        
+        # Check session
+        self.assertIn('g3wsuite_updaded_files', client.session)
+        self.assertIsInstance(client.session['g3wsuite_updaded_files'], list)
+        self.assertGreater(len(client.session['g3wsuite_updaded_files']), 0)
+        
+        # Test 3: Upload file with invalid format
+        invalid_file = SimpleUploadedFile(
+            name='test_file.exe',
+            content=b'fake_executable',
+            content_type='application/x-msdownload'
+        )
+        
+        response = client.post(url, {'file': invalid_file}, format='multipart')
+        self.assertEqual(response.status_code, 403)
+        jcontent = json.loads(response.content)
+        
+        self.assertFalse(jcontent['result'])
+        self.assertIn('error', jcontent)
+        self.assertIn('File type not allowed', jcontent['error'])
+        self.assertIn('exe', jcontent['error'])
+        
+        # Test 4: Upload another valid file (test session append)
+        pdf_content = BytesIO(b'%PDF-1.4 fake pdf content')
+        pdf_file = SimpleUploadedFile(
+            name='test_document.pdf',
+            content=pdf_content.read(),
+            content_type='application/pdf'
+        )
+        
+        initial_session_len = len(client.session['g3wsuite_updaded_files'])
+        response = client.post(url, {'file': pdf_file}, format='multipart')
+        self.assertEqual(response.status_code, 200)
+        
+        # Verify session was updated
+        new_session_len = len(client.session['g3wsuite_updaded_files'])
+        self.assertEqual(new_session_len, initial_session_len + 1)
+        
+        client.logout()

--- a/g3w-admin/qdjango/tests/test_usermediahandler.py
+++ b/g3w-admin/qdjango/tests/test_usermediahandler.py
@@ -1,0 +1,463 @@
+# coding=utf-8
+"""Test for UserMediaHandler class
+
+.. note:: This program is free software; you can redistribute it and/or modify
+     it under the terms of the Mozilla Public License 2.0.
+"""
+
+__author__ = 'lorenzetti@gis3w.it'
+__date__ = '2025-12-22'
+__copyright__ = 'Copyright 2025, GIS3W'
+
+import os
+import json
+import tempfile
+from io import BytesIO
+from unittest.mock import Mock, patch, MagicMock
+
+from django.test import TestCase, RequestFactory, override_settings
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from qdjango.vector import UserMediaHandler
+from qdjango.models import Layer
+from core.api.base.vector import MetadataVectorLayer
+from core.utils.db import build_dango_connection_name
+from core.utils.vector import BaseUserMediaHandler
+
+from .base import QdjangoTestBase, CURRENT_PATH, TEST_BASE_PATH, DATASOURCE_PATH
+
+
+@override_settings(
+    CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'some',
+        }
+    },
+    DATASOURCE_PATH=DATASOURCE_PATH,
+    LANGUAGE_CODE='en',
+    LANGUAGES=(
+        ('en', 'English'),
+    ),
+    MEDIA_ROOT='/tmp/g3wsuite_test_media/',
+    MEDIA_URL='/media/',
+    USER_MEDIA_ROOT='/tmp/g3wsuite_test_media/user_media/'
+)
+class UserMediaHandlerTest(QdjangoTestBase):
+    """Test UserMediaHandler functionality"""
+
+    def setUp(self):
+        super().setUp()
+        
+        # Create request factory
+        self.factory = RequestFactory()
+        
+        # Create test directories
+        os.makedirs(settings.MEDIA_ROOT, exist_ok=True)
+        os.makedirs(settings.USER_MEDIA_ROOT, exist_ok=True)
+        
+        # Get a layer with edittypes for testing
+        self.layer = self.project.instance.layer_set.first()
+        
+        # Mock layer edittypes for ExternalResource
+        self.layer.edittypes = json.dumps({
+            'photo': {
+                'widgetv2type': 'ExternalResource',
+                'fieldEditable': '1'
+            },
+            'document': {
+                'widgetv2type': 'ExternalResource',
+                'fieldEditable': '1'
+            }
+        })
+        self.layer.save()
+
+    def tearDown(self):
+        super().tearDown()
+        # Clean up test media directories
+        import shutil
+        if os.path.exists(settings.MEDIA_ROOT):
+            shutil.rmtree(settings.MEDIA_ROOT, ignore_errors=True)
+
+    def test_build_fs_path(self):
+        """Test build_fs_path static method"""
+        media_url = '/media/temp_uploads/1/test.jpg'
+        expected = '/tmp/g3wsuite_test_media/temp_uploads/1/test.jpg'
+        result = BaseUserMediaHandler.build_fs_path(media_url)
+        self.assertEqual(result, expected)
+
+    def test_init_handler(self):
+        """Test UserMediaHandler initialization"""
+        request = self.factory.get('/')
+        request.user = self.test_user1
+        
+        feature = {
+            'id': 1,
+            'properties': {
+                'name': 'Test Feature',
+                'photo': '/media/test.jpg'
+            }
+        }
+        
+        handler = UserMediaHandler(
+            file_name='test.jpg',
+            layer=self.layer,
+            feature=feature,
+            request=request
+        )
+        
+        self.assertEqual(handler.file_name, 'test.jpg')
+        self.assertEqual(handler.layer, self.layer)
+        self.assertEqual(handler.feature_properties, feature['properties'])
+        self.assertEqual(handler.request, request)
+
+    def test_set_layer_md5_source(self):
+        """Test set_layer_md5_source method"""
+        request = self.factory.get('/')
+        request.user = self.test_user1
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            request=request
+        )
+        
+        handler.set_layer_md5_source()
+        
+        # Check that md5 source is generated
+        self.assertIsNotNone(handler.layer_md5_source)
+        expected_md5 = build_dango_connection_name(self.layer.datasource)
+        self.assertEqual(handler.layer_md5_source, expected_md5)
+
+    def test_get_file_name(self):
+        """Test get_file_name method"""
+        handler = UserMediaHandler()
+        
+        # Test with full URL
+        uri = 'http://example.com/media/uploads/test_image.jpg'
+        result = handler.get_file_name(uri)
+        self.assertEqual(result, 'test_image.jpg')
+        
+        # Test with path
+        uri = '/media/temp_uploads/5/photo.png'
+        result = handler.get_file_name(uri)
+        self.assertEqual(result, 'photo.png')
+        
+        # Test with None
+        result = handler.get_file_name(None)
+        self.assertIsNone(result)
+
+    def test_get_path_to_save(self):
+        """Test get_path_to_save method"""
+        request = self.factory.get('/')
+        request.user = self.test_user1
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            request=request
+        )
+        
+        handler.set_layer_md5_source()
+        path = handler.get_path_to_save()
+        
+        expected_path = f'{settings.USER_MEDIA_ROOT}qdjango/{handler.layer_md5_source}'
+        self.assertEqual(path, expected_path)
+
+    def test_get_domain(self):
+        """Test get_domain method"""
+        # Test with HTTP
+        request = self.factory.get('/', HTTP_HOST='localhost:8000')
+        request.user = self.test_user1
+        
+        handler = UserMediaHandler(request=request)
+        domain = handler.get_domain()
+        self.assertEqual(domain, 'http://localhost:8000')
+        
+        # Test with HTTPS
+        request = self.factory.get('/', HTTP_HOST='example.com', secure=True)
+        request.user = self.test_user1
+        
+        handler = UserMediaHandler(request=request)
+        domain = handler.get_domain()
+        self.assertEqual(domain, 'https://example.com')
+
+    def test_new_path(self):
+        """Test _new_path method"""
+        request = self.factory.get('/')
+        request.user = self.test_user1
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            request=request
+        )
+        
+        handler.set_layer_md5_source()
+        file_name = 'test_photo.jpg'
+        path = handler._new_path(file_name)
+        
+        # Check that path is a valid URL pattern
+        self.assertIn('/me/', path)
+        self.assertIn('qdjango', path)
+        self.assertIn(handler.layer_md5_source, path)
+        self.assertIn(file_name, path)
+
+    def test_new_value_create_new_file(self):
+        """Test new_value method for creating new file"""
+        
+        request = self.factory.post('/')
+        request.user = self.test_user1
+        
+        # Create a temporary file in temp_uploads
+        temp_file_path = f'{settings.MEDIA_ROOT}temp_uploads/{self.test_user1.pk}/new_photo.jpg'
+        os.makedirs(os.path.dirname(temp_file_path), exist_ok=True)
+        with open(temp_file_path, 'wb') as f:
+            f.write(b'test image content')
+        
+        feature = {
+            'id': '_new_1',  # New feature
+            'properties': {
+                'name': 'Test',
+                'photo': f'{settings.MEDIA_URL}temp_uploads/{self.test_user1.pk}/new_photo.jpg'
+            }
+        }
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            feature=feature,
+            request=request
+        )
+        
+        handler.new_value()
+        
+        # Check that feature property was updated with new URL
+        self.assertIn('http://', feature['properties']['photo'])
+        self.assertIn('/me/', feature['properties']['photo'])
+
+    def test_new_value_update_existing_file(self):
+        """Test new_value method for updating existing file"""
+
+        
+        request = self.factory.post('/')
+        request.user = self.test_user1
+        
+        # Mock metadata_layer and get_feature
+        mock_metadata_layer = MagicMock()
+        mock_old_feature = {
+            'photo': f'{settings.MEDIA_URL}user-media/qdjango/old_hash/old_photo.jpg'
+        }
+        mock_metadata_layer.get_feature.return_value = mock_old_feature
+        mock_metadata_layer.layer = self.layer
+
+        # Create a temporary file in temp_uploads
+        temp_file_path = f'{settings.MEDIA_ROOT}temp_uploads/{self.test_user1.pk}/new_photo.jpg'
+        os.makedirs(os.path.dirname(temp_file_path), exist_ok=True)
+        with open(temp_file_path, 'wb') as f:
+            f.write(b'test image content')
+        
+        feature = {
+            'id': 1,  # Existing feature
+            'properties': {
+                'name': 'Test',
+                'photo': f'{settings.MEDIA_URL}temp_uploads/{self.test_user1.pk}/new_photo.jpg'
+            }
+        }
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            metadata_layer=mock_metadata_layer,
+            feature=feature,
+            request=request
+        )
+        
+        handler.new_value()
+
+
+
+    def test_new_value_with_duplicate_filename(self):
+        """Test new_value handles duplicate filenames by adding suffix"""
+        request = self.factory.post('/')
+        request.user = self.test_user1
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            request=request
+        )
+        
+        handler.set_layer_md5_source()
+        
+        # Create directory structure
+        path_to_save = handler.get_path_to_save()
+        os.makedirs(path_to_save, exist_ok=True)
+        
+        # Create existing file
+        existing_file = os.path.join(path_to_save, 'photo.jpg')
+        with open(existing_file, 'wb') as f:
+            f.write(b'existing content')
+        
+        # Create temp file
+        temp_file_path = f'{settings.MEDIA_ROOT}temp_uploads/{self.test_user1.pk}/photo.jpg'
+        os.makedirs(os.path.dirname(temp_file_path), exist_ok=True)
+        with open(temp_file_path, 'wb') as f:
+            f.write(b'new content')
+        
+        feature = {
+            'id': '_new_1',
+            'properties': {
+                'photo': f'{settings.MEDIA_URL}temp_uploads/{self.test_user1.pk}/photo.jpg'
+            }
+        }
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            feature=feature,
+            request=request
+        )
+        
+        handler.new_value()
+        
+        # Check that filename was modified with suffix
+        self.assertIn('photo_', feature['properties']['photo'])
+
+    def test_new_value_delete_file(self):
+        """Test new_value method for deleting file (empty value sent)"""
+        request = self.factory.post('/')
+        request.user = self.test_user1
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            request=request
+        )
+        
+        handler.set_layer_md5_source()
+        
+        # Create directory and file to delete
+        path_to_save = handler.get_path_to_save()
+        os.makedirs(path_to_save, exist_ok=True)
+        file_to_delete = os.path.join(path_to_save, 'old_photo.jpg')
+        with open(file_to_delete, 'wb') as f:
+            f.write(b'old content')
+        
+        # Mock metadata_layer
+        mock_metadata_layer = MagicMock()
+        mock_old_feature = {
+            'photo': f'{settings.MEDIA_URL}user-media/qdjango/{handler.layer_md5_source}/old_photo.jpg'
+        }
+        mock_metadata_layer.get_feature.return_value = mock_old_feature
+        mock_metadata_layer.layer = self.layer
+        
+        feature = {
+            'id': 1,
+            'properties': {
+                'photo': ''  # Empty value = delete
+            }
+        }
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            metadata_layer=mock_metadata_layer,
+            feature=feature,
+            request=request
+        )
+        
+        handler.new_value()
+        
+        # Verify file was deleted
+        self.assertFalse(os.path.exists(file_to_delete))
+
+    def test_change_value(self):
+        """Test change_value method"""
+        request = self.factory.post('/')
+        request.user = self.test_user1
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            request=request
+        )
+        
+        # Call change_value (should set layer_md5_source)
+        handler.change_value()
+        
+        self.assertIsNotNone(handler.layer_md5_source)
+
+    # def test_send_file(self, mock_send_file):
+    #     """Test send_file method"""
+
+    #     request = self.factory.get('/')
+    #     request.user = self.test_user1
+        
+    #     handler = UserMediaHandler(
+    #         file_name='test.jpg',
+    #         layer=self.layer,
+    #         request=request
+    #     )
+        
+    #     handler.send_file()
+        
+    #     # Verify send_file was called
+    #     self.assertTrue(mock_send_file.called)
+
+    def test_send_file_with_ds_md5(self):
+        """Test send_file method when layer is not found but ds_md5 is provided"""
+        request = self.factory.get('/')
+        request.user = self.test_user1
+        
+        handler = UserMediaHandler(
+            file_name='test.jpg',
+            layer=None,  # No layer
+            ds_md5='abc123hash',
+            request=request
+        )
+
+        # Create file to send
+        path_to_save = f'{settings.USER_MEDIA_ROOT}{handler.type}/{handler.ds_md5}'
+        os.makedirs(path_to_save, exist_ok=True)
+        file_path = os.path.join(path_to_save, 'test.jpg')
+        with open(file_path, 'wb') as f:
+            f.write(b'content to send')
+        
+        response = handler.send_file()
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Disposition'], 'inline; filename="test.jpg"')
+
+
+    def test_new_value_with_change_mode(self):
+        """Test new_value with change=True returns current value with mime_type"""
+
+        request = self.factory.post('/')
+        request.user = self.test_user1
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            request=request
+        )
+        
+        handler.set_layer_md5_source()
+        
+        # Create existing file
+        path_to_save = handler.get_path_to_save()
+        os.makedirs(path_to_save, exist_ok=True)
+        file_path = os.path.join(path_to_save, 'existing.jpg')
+        with open(file_path, 'wb') as f:
+            f.write(b'existing content')
+        
+        feature = {
+            'id': 1,
+            'properties': {
+                'photo': f'{settings.MEDIA_URL}user-media/qdjango/{handler.layer_md5_source}/existing.jpg'
+            }
+        }
+        
+        handler = UserMediaHandler(
+            layer=self.layer,
+            feature=feature,
+            request=request
+        )
+        
+        handler.new_value(change=True)
+        
+        # Check that property is now a dict with value and mime_type
+        self.assertIsInstance(feature['properties']['photo'], dict)
+        self.assertIn('value', feature['properties']['photo'])
+        self.assertIn('mime_type', feature['properties']['photo'])


### PR DESCRIPTION
On uploading of media during the editing on line sessions, the media i saved inside a folder's name building with the datasource of the layer.

So if the layer's datasource change , i.e. after an QGIS project update because i.e. the table's name is changed (this is a example for Postis layers) the path to the odl media is not more reachable.

This PR add make a refactoring of the end media path to store into layer data, the 'layer id' url parameter it was changed with the originale md5 'layer's datasource' create on media saving, in this way also the media with different datasource can be reachable.
