### PR TITLE
Add client legend settings update to initialization

### DIFF
--- a/g3w-admin/base/settings/__init__.py
+++ b/g3w-admin/base/settings/__init__.py
@@ -31,6 +31,13 @@ try:
 except:
     pass
 
+# For client settings
+try:
+    BASE_G3W_CLIENT_LEGEND.update(G3W_CLIENT_LEGEND)
+    G3W_CLIENT_LEGEND = BASE_G3W_CLIENT_LEGEND
+except:
+    pass
+
 if TESTING:
     try:
         from .tests_settings import *


### PR DESCRIPTION
This PR fix the BASE_G3W_CLIENT_LEGEND settings usage.
