### PR TITLE
🐛 Relation layer editing capabilities for a user

### DIFF
--- a/g3w-admin/editing/static/editing/js/components/relation.js
+++ b/g3w-admin/editing/static/editing/js/components/relation.js
@@ -1268,7 +1268,7 @@ export default ({
       /**
        * editing a constraint type
        */
-      this.capabilities = this.parentWorkflow.getLayer().config.editing.capabilities;
+      this.capabilities = this.getLayer().config?.editing?.capabilities ?? [];
 
 
       /**


### PR DESCRIPTION
In case a user has some  editing capabilities on a specific layer, need to check the constraints fro a relation layer on editing and not for a parent layer

Project: https://dev.g3wsuite.it/it/map/demo-311/

User: viewer1

Building capabilities

<img width="664" height="366" alt="Screenshot_20260407_114249" src="https://github.com/user-attachments/assets/b9620252-2e65-4aa9-97e6-2a0bb9a545e8" />

Maintenance works capabilities

<img width="664" height="366" alt="Screenshot_20260407_114218" src="https://github.com/user-attachments/assets/57d6412d-e3c9-4248-8896-c746233dc8c9" />


### Before

Missing delete feature

<img width="394" height="508" alt="Screenshot_20260407_114449" src="https://github.com/user-attachments/assets/ab52fe48-36cf-4f1e-8021-58f653666440" />


### After

<img width="394" height="508" alt="Screenshot_20260407_114356" src="https://github.com/user-attachments/assets/f870ed1e-dbde-43ee-a7df-cddc71cf282e" />
