### PR TITLE
Set OL vector layer visible when starting toolbox (editing layer)

### DIFF
--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -156,7 +156,7 @@ export class ToolBox extends Emitter {
 
     if ('image' === _layer.getType()) {
       //Need to set always visible otherwise if catalog layer is not visible no fetaures are visible on map
-      layer = new Layer({..._layer.state, ...{ visible: true } }, { TYPE: 'vector' });
+      layer = new Layer(layer.state, { TYPE: 'vector' });
     }
 
 
@@ -1973,6 +1973,9 @@ export class ToolBox extends Emitter {
       if (this.state.layer.config.editing.layer_style && this.#current_style !== this.state.layer.config.editing.layer_style) {
         await getCatalogLayerById(this.state.id).changeStyle(this.state.layer.config.editing.layer_style);
       }
+
+      //@since 4.0.1 set visible layer in case of image layer
+      this.state.layer.getOLLayer()?.setVisible(true);
 
     });
   };

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1975,7 +1975,7 @@ export class ToolBox extends Emitter {
       }
 
       //@since 4.0.1 set visible layer in case of image layer
-      this.state.layer.getOLLayer()?.setVisible(true);
+      this.state.layer.getOLLayer?.()?.setVisible(true);
 
     });
   };

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1809,8 +1809,8 @@ export class ToolBox extends Emitter {
   }
 
   /**
-   *
    * Start editing
+   * 
    * @param options
    * @param { Object } options
    * @param { boolean } [options.selected=true]
@@ -1822,7 +1822,7 @@ export class ToolBox extends Emitter {
    */
   start(options = {}) {
     return new Promise(async (resolve, reject) => {
-      //get current style of layer
+      // get current style of layer
       this.#current_style = this.state.layer.getCurrentStyle().name;
 
       const plugin = GUI.getPlugin('editing');
@@ -1849,7 +1849,7 @@ export class ToolBox extends Emitter {
   
       options.filter = constraints?.filter || this.constraints.filter || options.filter;
 
-      //register lock features to show a message
+      // register lock features to show a message
       const unKeyLock = this._editor.onceafter('featuresLockedByOtherUser', () => {
         GUI.showUserMessage({
           type:     'warning',
@@ -1858,22 +1858,22 @@ export class ToolBox extends Emitter {
         })
       });
   
-      //add featuresLockedByOtherUser setter
+      // add featuresLockedByOtherUser setter
       this.state._unregisterStartSettersEventsKey.push(() => this._editor.un('featuresLockedByOtherUser', unKeyLock));
 
       // check if can we edit based on scale contraint (vector layer)
       if (this.state._constraints.scale) {
-        //set false
+        // set false
         this.state.editing.canEdit = false;
-        //reset/close eventually user message scale on stop
+        // reset/close eventually user message scale on stop
         this.state._unregisterStartSettersEventsKey.push(() => this._handleScaleConstraint(true));
-        //listen selected attribute
+        // listen selected attribute
         this.state._unregisterStartSettersEventsKey.push(Vue.watch(() => this.state.selected, async bool => { await Vue.nextTick(); this._handleScaleConstraint(!bool); }, { immediate: true }));
-        //await scale set for get features
+        // await scale set for get features
         await new Promise(resolve => {
-          //set as resolve handler to resolve waiting get features from server
+          // set as resolve handler to resolve waiting get features from server
           this.#startAsync = resolve;
-          //SELECTED AND NOT REGISTER MAP CHANGE RESOLUTION
+          // SELECTED AND NOT REGISTER MAP CHANGE RESOLUTION
           this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint(false) ), 600));
           // click to fit zoom scale constraint
           this.#events.push(
@@ -1893,7 +1893,7 @@ export class ToolBox extends Emitter {
         
       }
 
-      //reset eventually message
+      // reset eventually message
       if (!this.state._constraints.scale) {
         GUI.setModal(false);
       }
@@ -1904,7 +1904,7 @@ export class ToolBox extends Emitter {
 
       const handlerAfterSessionGetFeatures = async promise => {
         this.emit('start-editing');
-        //set unique fields values
+        // set unique fields values
         await setLayerUniqueFieldValues(this.getId());
         try {
           const features = await promise;
@@ -1969,12 +1969,12 @@ export class ToolBox extends Emitter {
         GUI.disableClickMapControls(true);
       }
 
-      //@since 4.0.1 change layer style
+      // wait for features before changing editing layer style 
       if (this.state.layer.config.editing.layer_style && this.#current_style !== this.state.layer.config.editing.layer_style) {
         await getCatalogLayerById(this.state.id).changeStyle(this.state.layer.config.editing.layer_style);
       }
 
-      //@since 4.0.1 set OL vector layer visible when starting toolbox (eg. image layers whose catalog layer may be hidden)
+      // force vector layer visibity when starting toolbox (eg. image layers whose catalog layer may be hidden)
       this.state.layer.getOLLayer?.()?.setVisible(true);
 
     });

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -155,8 +155,8 @@ export class ToolBox extends Emitter {
     }
 
     if ('image' === _layer.getType()) {
-      //Need to set always visible otherwise if catalog layer is not visible no fetaures are visible on map
-      layer = new Layer(layer.state, { TYPE: 'vector' });
+      // clone state to keep catalog/project layer state independent from editing vector layer state
+      layer = new Layer({..._layer.state}, { TYPE: 'vector' });
     }
 
 
@@ -1974,7 +1974,7 @@ export class ToolBox extends Emitter {
         await getCatalogLayerById(this.state.id).changeStyle(this.state.layer.config.editing.layer_style);
       }
 
-      //@since 4.0.1 set visible layer in case of image layer
+      //@since 4.0.1 set OL vector layer visible when starting toolbox (eg. image layers whose catalog layer may be hidden)
       this.state.layer.getOLLayer?.()?.setVisible(true);
 
     });

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -155,8 +155,8 @@ export class ToolBox extends Emitter {
     }
 
     if ('image' === _layer.getType()) {
-      // clone state to keep catalog/project layer state independent from editing vector layer state
-      layer = new Layer({..._layer.state}, { TYPE: 'vector' });
+      // state of catalog/project layer state need to be in sync with editing vector layer state
+      layer = new Layer(_layer.state, { TYPE: 'vector' });
     }
 
 


### PR DESCRIPTION
## Summary of changes

Adjust editing (session) layer visibility so that the OpenLayers vector layer used for editing is made visible when the toolbox starts, aiming to keep the catalog/project layer state consistent (important when an “editing style” changes the `editor_form_structure`).

Changes:

- Stop forcing `visible: true` into the derived vector Layer state for image layers.
- Explicitly set the editing layer’s OL layer visibility to true when starting the toolbox session.


## How to test

### 1. Go to: https://dev.g3wsuite.it/en/map/g3w-suite-demo/qdjango/97/

### 2. Change Building style: `Categorized` → Query a Building → no Relation tab

<img width="1920" height="589" alt="Screenshot_20260511_105556" src="https://github.com/user-attachments/assets/67352b35-39e0-4e31-ba95-31f4e887e31b" />

### 3. Change Building style: `Graduated` → Query a Building → has Relation tab

<img width="1920" height="449" alt="Screenshot_20260511_105453" src="https://github.com/user-attachments/assets/9ababd20-a5d0-419b-812f-7fcbf24b213a" />

### 4. Activate editing → Building's style automatically changes in: `Categorized`

<img width="1920" height="901" alt="Screenshot_20260511_105104" src="https://github.com/user-attachments/assets/905436f7-18c2-4eba-a1e9-d43a9ee47be2" />

### 5. Run a Query → no Relation tab (`Categorized`)

<img width="1920" height="901" alt="Screenshot_20260511_105104" src="https://github.com/user-attachments/assets/905436f7-18c2-4eba-a1e9-d43a9ee47be2" />

### 5. Start editing a feature

#### Before: → Relations tab still visible (`Graduated`)

<img width="1920" height="827" alt="Screenshot_20260511_105308" src="https://github.com/user-attachments/assets/c347ba92-6c2a-45e0-8caa-f3f7d9779db3" />

#### After: → Relations tab is hidden (`Categorized`)

<img width="1920" height="979" alt="Screenshot_20260511_105729" src="https://github.com/user-attachments/assets/a1597c66-b10e-4107-bf82-12b1141a179d" />