### PR TITLE
Scale contraint not shown editing starts (toolbox)

### DIFF
--- a/g3w-admin/editing/static/editing/js/components/editing.js
+++ b/g3w-admin/editing/static/editing/js/components/editing.js
@@ -249,15 +249,13 @@ export default ({
     },
 
     /**
-     * @param id
+     * @param id toolbox id
      */
     async selectToolBox(id) {
-      //wait eventually start/stop toolbox
+      // wait for DOM updates
       await this.$nextTick();
-      const toolbox = GUI.getPlugin('editing').getToolBoxById(id); // get toolbox by id
-      // set the current selected toolbox to true
+      const toolbox = GUI.getPlugin('editing').getToolBoxById(id);
       toolbox.setSelected(true);
-      //set current tooboxselected
       this.state.toolboxselected = toolbox;
     },
 

--- a/g3w-admin/editing/static/editing/js/components/editing.js
+++ b/g3w-admin/editing/static/editing/js/components/editing.js
@@ -254,13 +254,9 @@ export default ({
     async selectToolBox(id) {
       //wait eventually start/stop toolbox
       await this.$nextTick();
-      const toolbox          = GUI.getPlugin('editing').getToolBoxById(id); // get toolbox by id
-      const toolboxes        = GUI.getPlugin('editing').getToolBoxes();     // get all toolboxes
-      //set current selected toolbox false
-      toolboxes.find(t => t.isSelected())?.setSelected(false);         
+      const toolbox = GUI.getPlugin('editing').getToolBoxById(id); // get toolbox by id
       // set the current selected toolbox to true
       toolbox.setSelected(true);
-      
       //set current tooboxselected
       this.state.toolboxselected = toolbox;
     },

--- a/g3w-admin/editing/static/editing/js/g3w-iframe.js
+++ b/g3w-admin/editing/static/editing/js/g3w-iframe.js
@@ -172,7 +172,7 @@ export class IframeEditor extends Emitter {
 
       // in case of no feature add avent subscribe
       this.#onPlugin('addfeature', feature => {
-        Object.keys(config.data.properties).forEach(p => feature.set(p, config.data.properties[p]));
+        Object.keys(config.properties).forEach(p => feature.set(p, config.properties[p]));
 
         let activeTool;
         const disableToolboxes = [];
@@ -198,7 +198,8 @@ export class IframeEditor extends Emitter {
             activeTool.setEnabled(!bool);
             disableToolboxes.forEach(t => t.setEditing(!bool))
           });
-          this.#onPlugin('cancelform', () => { e1(); }); // runs callback 
+
+          this.#onPlugin('cancelform', () => { this.#promise.cb(); }); // runs callback 
         }
       });
 

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -2268,6 +2268,10 @@ export class ToolBox extends Emitter {
    * @param bool
    */
   setSelected(bool = false) {
+    if (bool) {
+      //set current selected toolbox false
+      GUI.getPlugin('editing').getToolBoxes()?.find?.(t => t.isSelected())?.setSelected(false);         
+    }
     //set state of selected attribute
     this.state.selected = bool;
     //In case of unselection and acive tool, stop active tool

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -2274,21 +2274,19 @@ export class ToolBox extends Emitter {
    * @param bool
    */
   setSelected(bool = false) {
+    // un-select current toolbox
     if (bool) {
-      //set current selected toolbox false
-      GUI.getPlugin('editing').getToolBoxes()?.find?.(t => t.isSelected())?.setSelected(false);         
+      GUI.getPlugin('editing').getToolBoxes()?.find?.(t => t.isSelected())?.setSelected(false);
     }
-    //set state of selected attribute
     this.state.selected = bool;
-    //In case of unselection and acive tool, stop active tool
+    // stop active tool
     if (!this.state.selected && this.state.activetool) {
       this.stopActiveTool();
     }
-
+    // reset warning message
     if (!this.state.selected) {
       this.clearMessage();
     }
-
   }
 
   /**

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -343,8 +343,8 @@ export class ToolBox extends Emitter {
         father       : layer.isFather(),
         canEdit      : true
       },
-      /** @since g3w-client-plugin-editing@v3.7.0 store key events setters */
-      _unregisterStartSettersEventsKey: [],
+      /** store events un-setters */
+      _unsetters: [],
       _getFeaturesOption: {},
       _layerType: layer.getType() || 'vector',
       _enabledtools: undefined,
@@ -1772,7 +1772,7 @@ export class ToolBox extends Emitter {
    * @since 3.8.0 Handle scale constraint
    * @private
    */
-  _handleScaleConstraint() {    
+  _handleScaleConstraint() {
     // get features from server or wait to start
     const map = GUI.getMap();
 
@@ -1855,19 +1855,21 @@ export class ToolBox extends Emitter {
       });
   
       // add featuresLockedByOtherUser setter
-      this.state._unregisterStartSettersEventsKey.push(() => this._editor.un('featuresLockedByOtherUser', unKeyLock));
+      this.state._unsetters.push(() => this._editor.un('featuresLockedByOtherUser', unKeyLock));
 
       // check if can we edit based on scale contraint (vector layer)
       if (this.state._constraints.scale) {
         // set false
         this.state.editing.canEdit = false;
         //reset/close eventually user message scale on stop
-        this.state._unregisterStartSettersEventsKey.push(() => this._handleScaleConstraint());
+        this.state._unsetters.push(() => this._handleScaleConstraint());
         await new Promise(resolve => {
           // set as resolve handler to resolve waiting get features from server
           this.#startAsync = resolve;
           //listen selected attribute
-          this.state._unregisterStartSettersEventsKey.push(Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true }));
+          this.state._unsetters.push(
+            Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true })
+          );
           //await scale set for get features
           //SELECTED AND NOT REGISTER MAP CHANGE RESOLUTION
           this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(async () => {
@@ -2012,8 +2014,8 @@ export class ToolBox extends Emitter {
       this.disableCanEditEvent();
     }
 
-    this.state._unregisterStartSettersEventsKey.forEach(fnc => fnc());
-    this.state._unregisterStartSettersEventsKey = [];
+    this.state._unsetters.forEach(fnc => fnc());
+    this.state._unsetters = [];
 
     this.#events.forEach(k => ol.Observable.unByKey(k));
     this.#events.splice(0);
@@ -3200,7 +3202,7 @@ export class ToolBox extends Emitter {
         this.#getFeaturesEvent.fnc   = debounce(fnc, 300);
       
         this.#events.push(GUI.getMap().on('moveend', this.#getFeaturesEvent.fnc));
-        this.state._unregisterStartSettersEventsKey.push(Vue.watch(() => this.state.selected, async selected => {
+        this.state._unsetters.push(Vue.watch(() => this.state.selected, async selected => {
           //in case of select toolbox and layer already started editing get features
           if (selected && this.#start) { 
             this.#getFeaturesEvent.fnc();

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1863,32 +1863,32 @@ export class ToolBox extends Emitter {
 
       // check if can we edit based on scale contraint (vector layer)
       if (this.state._constraints.scale) {
+        const { promise, res, rej } = Promise.withResolvers();
         this.state.editing.canEdit = false;
         // reset user message scale (on stop)
         this.state._unsetters.push(() => this._handleScaleConstraint());
-        await new Promise(resolve => {
-          // set as resolve handler to resolve waiting get features from server
-          this.#startAsync = resolve;
-          // listen selected attribute
-          this.state._unsetters.push(Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true }));
-          // await scale set for get features
-          this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint()), 600));
-          // click to fit zoom scale constraint
-          this.#events.push(
-            GUI.getMap().on('click', e => {
-              if (this.state.selected && !this.state.editing.canEdit) {
-                GUI.getMap().getView().animate(
-                  { duration: 200, center: e.coordinate },
-                  { duration: 200, resolution: getResolutionFromScale(this.state._constraints.scale, GUI.getMapUnits()) || GUI.getMap().getView().getResolution() }
-                );
-              }
-            })
-          );
-
-          // if click on start toolbox can edit
-          if (this.state.editing.canEdit) { resolve(); }
-        })
-        
+        // set as resolve handler to resolve waiting get features from server
+        this.#startAsync = res;
+        // listen selected attribute
+        this.state._unsetters.push(Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true }));
+        // await scale set for get features
+        this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint()), 600));
+        // click to fit zoom scale constraint
+        this.#events.push(
+          GUI.getMap().on('click', e => {
+            if (this.state.selected && !this.state.editing.canEdit) {
+              GUI.getMap().getView().animate(
+                { duration: 200, center: e.coordinate },
+                { duration: 200, resolution: getResolutionFromScale(this.state._constraints.scale, GUI.getMapUnits()) || GUI.getMap().getView().getResolution() }
+              );
+            }
+          })
+        );
+        // if click on start toolbox can edit
+        if (this.state.editing.canEdit) {
+          res();
+        }
+        await promise;
       }
 
       // reset eventually message

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1773,17 +1773,16 @@ export class ToolBox extends Emitter {
    * @private
    */
   async _handleScaleConstraint() {
-    // To ensure that selected toolbox run is logic after all not selected toolboxes to ensure that GUI Modal and cuursor is set in right state
-    // otherwise it happen that selected behaviour  is "overwrite" by unselected toolboxes that run after selected one and set GUI Modal and cuursor in wrong state
+    // wait until previous toolbox is un-selected to prevent conflicts when running "GUI.setModal" and `control.setMouseCursor`.
     if (this.state.selected) {
       await Promise.resolve();
     }
-    // get features from server or wait to start
+
     const map = GUI.getMap();
 
     this.state.editing.canEdit = getScaleFromResolution(map.getView().getResolution()) <= this.state._constraints.scale;
 
-    //check if start method is called
+    // check if start method is called
     const showZoomCursor = this.state.selected && (this.#start || this.#startAsync) && !this.state.editing.canEdit;
 
     const control        = GUI.getCurrentToggledMapControl();
@@ -1798,9 +1797,9 @@ export class ToolBox extends Emitter {
       this.#startAsync();
     }
 
-    //@since 4.0.1 set modal true in case of openFormStep is running
+    // set modal when running an `OpenFormStep`
     if (this.state.editing.canEdit && this.state.activetool?.op.getRunningStep() instanceof OpenFormStep) {
-      //Check if current interaction is pickLayer 
+      // check if current interaction is pickLayer 
       GUI.setModal('picklayer' !== map.getInteractions().item(map.getInteractions().getLength() -1).get('id') );
       return;
     }

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -3200,12 +3200,17 @@ export class ToolBox extends Emitter {
         this.#getFeaturesEvent.fnc   = debounce(fnc, 300);
       
         this.#events.push(GUI.getMap().on('moveend', this.#getFeaturesEvent.fnc));
-        this.state._unsetters.push(Vue.watch(() => this.state.selected, async selected => {
-          //in case of select toolbox and layer already started editing get features
-          if (selected && this.#start) { 
-            this.#getFeaturesEvent.fnc();
-          }
-        }));
+        this.state._unsetters.push(
+          Vue.watch(
+            () => this.state.selected,
+            async selected => {
+              // in case of select toolbox and layer already started editing get features
+              if (selected && this.#start) { 
+                this.#getFeaturesEvent.fnc();
+              }
+            }
+          )
+        );
 
         if (GUI.getContentLength()) {
           GUI.once('closecontent', () => {

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1793,7 +1793,7 @@ export class ToolBox extends Emitter {
 
     map.getViewport().classList.toggle('ol-zoom-in', showZoomCursor);
 
-    if (this.state.editing.canEdit && this.#startAsync) {
+    if (this.state.editing.canEdit && this.state.selected && this.#startAsync) {
       this.#startAsync();
     }
 

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1863,14 +1863,20 @@ export class ToolBox extends Emitter {
         this.state.editing.canEdit = false;
         //reset/close eventually user message scale on stop
         this.state._unregisterStartSettersEventsKey.push(() => this._handleScaleConstraint());
-        //listen selected attribute
-        this.state._unregisterStartSettersEventsKey.push(Vue.watch(() => this.state.selected, async () => { await Vue.nextTick(); this._handleScaleConstraint(); }, { immediate: true }));
-        //await scale set for get features
         await new Promise(resolve => {
           //set as resolve handler to resolve waiting get features from server
           this.#startAsync = resolve;
+          //listen selected attribute
+          this.state._unregisterStartSettersEventsKey.push(Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true }));
+          //await scale set for get features
           //SELECTED AND NOT REGISTER MAP CHANGE RESOLUTION
-          this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint() ), 600));
+          this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(async () => {
+            //selected nee to wait handle by not selected in editing toolboxes
+            if (this.state.selected) {
+              await Promise.resolve();
+            }
+            this._handleScaleConstraint();
+          }), 600));
           // click to fit zoom scale constraint
           this.#events.push(
             GUI.getMap().on('click', e => {

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1772,7 +1772,12 @@ export class ToolBox extends Emitter {
    * @since 3.8.0 Handle scale constraint
    * @private
    */
-  _handleScaleConstraint() {
+  async _handleScaleConstraint() {
+    // To ensure that selected toolbox run is logic after all not selected toolboxes to ensure that GUI Modal and cuursor is set in right state
+    // otherwise it happen that selected behaviour  is "overwrite" by unselected toolboxes that run after selected one and set GUI Modal and cuursor in wrong state
+    if (this.state.selected) {
+      await Promise.resolve();
+    }
     // get features from server or wait to start
     const map = GUI.getMap();
 
@@ -1871,14 +1876,7 @@ export class ToolBox extends Emitter {
             Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true })
           );
           //await scale set for get features
-          //SELECTED AND NOT REGISTER MAP CHANGE RESOLUTION
-          this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(async () => {
-            //selected nee to wait handle by not selected in editing toolboxes
-            if (this.state.selected) {
-              await Promise.resolve();
-            }
-            this._handleScaleConstraint();
-          }), 600));
+          this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint()), 600));
           // click to fit zoom scale constraint
           this.#events.push(
             GUI.getMap().on('click', e => {

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1863,18 +1863,15 @@ export class ToolBox extends Emitter {
 
       // check if can we edit based on scale contraint (vector layer)
       if (this.state._constraints.scale) {
-        // set false
         this.state.editing.canEdit = false;
-        //reset/close eventually user message scale on stop
+        // reset user message scale (on stop)
         this.state._unsetters.push(() => this._handleScaleConstraint());
         await new Promise(resolve => {
           // set as resolve handler to resolve waiting get features from server
           this.#startAsync = resolve;
-          //listen selected attribute
-          this.state._unsetters.push(
-            Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true })
-          );
-          //await scale set for get features
+          // listen selected attribute
+          this.state._unsetters.push(Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true }));
+          // await scale set for get features
           this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint()), 600));
           // click to fit zoom scale constraint
           this.#events.push(

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1433,7 +1433,7 @@ export class ToolBox extends Emitter {
                           /** @since g3w-client-plugin-editing@v3.8.0 */
                           (isSplitted ? resolve : reject)(inputs);
                           //need to set timeout promise, because at the end of the workflow all user messages are cleared
-                          await new Promise((r) => setTimeout(r, 600));
+                          await new Promise(r => setTimeout(r, 600));
                           GUI.showUserMessage({
                             type:      isSplitted ? 'success': 'warning',
                             message:   isSplitted ? 'plugins.editing.messages.splitted' : 'plugins.editing.messages.nosplittedfeature',
@@ -1678,7 +1678,7 @@ export class ToolBox extends Emitter {
       layerId,
       relations: layer.getRelations() ? layer.getRelations().getArray() : [],
     })
-      .filter(relation => relation.getFather() === layerId)
+      .filter(r => layerId === r.getFather())
       .forEach(relation => {
         const relationId = getRelationId({ layerId, relation });
         // In case of no editing is started (click on pencil of relation layer) need to stop (unlock) features
@@ -1936,7 +1936,7 @@ export class ToolBox extends Emitter {
             this.startLoading();
             this.setFeaturesOptions({ filter: options.filter });
             try {
-              await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption))
+              await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption));
             } catch(e) {
               console.warn(e);
               this.setEditing(false);
@@ -3177,7 +3177,11 @@ export class ToolBox extends Emitter {
             && this.state.editing.canEdit
             && 0 === GUI.getContentLength()
           ) {
-            this.state._getFeaturesOption.filter.bbox = GUI.getMapBBOX();
+            const newBbox = GUI.getMapBBOX();
+            const curBbox = this.state._getFeaturesOption.filter.bbox;
+            // skip request if bbox hasn't changed
+            if (newBbox.every((v, i) => v === curBbox?.[i])) { return; }
+            this.state._getFeaturesOption.filter.bbox = newBbox;
             this.state.loading = true;
             await this._session.getFeatures(this.state._getFeaturesOption);
             this.state.loading = false;
@@ -3185,7 +3189,15 @@ export class ToolBox extends Emitter {
         };
         this.#getFeaturesEvent.event = 'moveend';
         this.#getFeaturesEvent.fnc   = debounce(fnc, 300);
+      
         this.#events.push(GUI.getMap().on('moveend', this.#getFeaturesEvent.fnc));
+        this.state._unregisterStartSettersEventsKey.push(Vue.watch(() => this.state.selected, async selected => {
+          //in case of select toolbox and layer already started editing get features
+          if (selected && this.#start) { 
+            this.#getFeaturesEvent.fnc();
+          }
+        }));
+
         if (GUI.getContentLength()) {
           GUI.once('closecontent', () => {
             const map = GUI.getMap();

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1770,24 +1770,20 @@ export class ToolBox extends Emitter {
 
   /**
    * @since 3.8.0 Handle scale constraint
-   * @sto <Boolean> stop true when called from stop method
    * @private
    */
-  _handleScaleConstraint(stop = false) {
-    
+  _handleScaleConstraint() {    
     // get features from server or wait to start
     const map = GUI.getMap();
 
     this.state.editing.canEdit = getScaleFromResolution(map.getView().getResolution()) <= this.state._constraints.scale;
 
     //check if start method is called
-    const in_editing     = (this.#start || this.#startAsync);
-
-    const showZoomCursor = !stop && this.state.selected && !this.state.editing.canEdit;
+    const showZoomCursor = this.state.selected && (this.#start || this.#startAsync) && !this.state.editing.canEdit;
 
     const control        = GUI.getCurrentToggledMapControl();
 
-    if (control?.cursorClass && (stop || in_editing)) {
+    if (control?.cursorClass) {
       control.setMouseCursor(!showZoomCursor);
     }
 
@@ -1803,9 +1799,9 @@ export class ToolBox extends Emitter {
       GUI.setModal('picklayer' !== map.getInteractions().item(map.getInteractions().getLength() -1).get('id') );
       return;
     }
+    
     // async show message because another toolbox can be unselected before
     GUI.setModal(showZoomCursor, this.messages.constraint.scale);
-    
   }
 
   /**
@@ -1866,15 +1862,15 @@ export class ToolBox extends Emitter {
         //set false
         this.state.editing.canEdit = false;
         //reset/close eventually user message scale on stop
-        this.state._unregisterStartSettersEventsKey.push(() => this._handleScaleConstraint(true));
+        this.state._unregisterStartSettersEventsKey.push(() => this._handleScaleConstraint());
         //listen selected attribute
-        this.state._unregisterStartSettersEventsKey.push(Vue.watch(() => this.state.selected, async bool => { await Vue.nextTick(); this._handleScaleConstraint(!bool); }, { immediate: true }));
+        this.state._unregisterStartSettersEventsKey.push(Vue.watch(() => this.state.selected, async () => { await Vue.nextTick(); this._handleScaleConstraint(); }, { immediate: true }));
         //await scale set for get features
         await new Promise(resolve => {
           //set as resolve handler to resolve waiting get features from server
           this.#startAsync = resolve;
           //SELECTED AND NOT REGISTER MAP CHANGE RESOLUTION
-          this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint(false) ), 600));
+          this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint() ), 600));
           // click to fit zoom scale constraint
           this.#events.push(
             GUI.getMap().on('click', e => {
@@ -1996,6 +1992,9 @@ export class ToolBox extends Emitter {
    */
   async stop() {
 
+    this.#start      = false;
+    this.#startAsync = null;
+
     if (this.state.layer.config.editing.layer_style && this.#current_style && this.#current_style !== this.state.layer.config.editing.layer_style) {
       await getCatalogLayerById(this.state.id).changeStyle(this.#current_style);
     }
@@ -2013,7 +2012,7 @@ export class ToolBox extends Emitter {
     this.#unwatches.forEach(uw => uw());
     this.#unwatches.splice(0);
 
-    this.#startAsync = null;
+    
 
     const is_started = !!this.isSessionStarted();
 
@@ -2029,8 +2028,6 @@ export class ToolBox extends Emitter {
     if (0 === GUI.getPlugin('editing').state.stopChain.size) {
       this.startLoading();
     }
-
-
 
     // Check if father relation is editing and has commit feature
     const fathersInEditing = GUI.getPlugin('editing').getLayerById(this.state.id).getFathers().filter(id => {
@@ -2057,8 +2054,6 @@ export class ToolBox extends Emitter {
 
     try {
       await this._session.stop();
-      //set start to false
-      this.#start           = false
       this.stopLoading();
       this.setEditing(false);
       this.state._getFeaturesOption = {};
@@ -3178,6 +3173,7 @@ export class ToolBox extends Emitter {
           if (
             //added ApplicationState.online
             ApplicationState.online
+            && this.state.selected
             && this.state.editing.canEdit
             && 0 === GUI.getContentLength()
           ) {

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1863,7 +1863,7 @@ export class ToolBox extends Emitter {
 
       // check if can we edit based on scale contraint (vector layer)
       if (this.state._constraints.scale) {
-        const { promise, res, rej } = Promise.withResolvers();
+        const { promise, resolve: res, reject: rej } = Promise.withResolvers();
         this.state.editing.canEdit = false;
         // reset user message scale (on stop)
         this.state._unsetters.push(() => this._handleScaleConstraint());

--- a/g3w-admin/editing/static/editing/js/index.js
+++ b/g3w-admin/editing/static/editing/js/index.js
@@ -994,7 +994,7 @@ new (class extends Plugin {
    * @since g3w-client-plugin-editing@v3.7.2
    */
   showPanel(options = {}) {
-    if (options.toolboxes && Array.isArray(options.toolboxes)) {
+    if (Array.isArray(options.toolboxes)) {
       this.getToolBoxes().forEach(tb => tb.setShow(options.toolboxes.includes(tb.getId())));
     }
     this.showEditingPanel(options);

--- a/g3w-admin/editing/static/editing/js/index.js
+++ b/g3w-admin/editing/static/editing/js/index.js
@@ -993,11 +993,11 @@ new (class extends Plugin {
    *
    * @since g3w-client-plugin-editing@v3.7.2
    */
-  showPanel(options = {}) {
+  async showPanel(options = {}) {
     if (Array.isArray(options.toolboxes)) {
       this.getToolBoxes().forEach(tb => tb.setShow(options.toolboxes.includes(tb.getId())));
     }
-    this.showEditingPanel(options);
+    return await this.showEditingPanel(options);
   }
 
   /**

--- a/g3w-admin/editing/static/editing/js/index.js
+++ b/g3w-admin/editing/static/editing/js/index.js
@@ -855,7 +855,7 @@ new (class extends Plugin {
    */
   async startEditing(layerId, options = {}) {
     const toolbox = this.getToolBoxById(layerId);
-    //need to set selected toolbox before start editing to show scale constraint message related to layer
+    // select toolbox before start editing (to display scale constraint message related to layer)
     toolbox.setSelected(true);
     const data    = await toolbox.start(options);
     return data ? { toolbox, data } : toolbox;

--- a/g3w-admin/editing/static/editing/js/index.js
+++ b/g3w-admin/editing/static/editing/js/index.js
@@ -855,8 +855,6 @@ new (class extends Plugin {
    */
   async startEditing(layerId, options = {}) {
     const toolbox = this.getToolBoxById(layerId);
-    //set current selected toolbox false
-    this.getToolBoxes().find(t => t.isSelected())?.setSelected(false);         
     //need to set selected toolbox before start editing to show scale constraint message related to layer
     toolbox.setSelected(true);
     const data    = await toolbox.start(options);

--- a/g3w-admin/editing/static/editing/js/index.js
+++ b/g3w-admin/editing/static/editing/js/index.js
@@ -855,6 +855,8 @@ new (class extends Plugin {
    */
   async startEditing(layerId, options = {}) {
     const toolbox = this.getToolBoxById(layerId);
+    //set current selected toolbox false
+    this.getToolBoxes().find(t => t.isSelected())?.setSelected(false);         
     //need to set selected toolbox before start editing to show scale constraint message related to layer
     toolbox.setSelected(true);
     const data    = await toolbox.start(options);

--- a/g3w-admin/editing/static/editing/js/index.js
+++ b/g3w-admin/editing/static/editing/js/index.js
@@ -855,6 +855,8 @@ new (class extends Plugin {
    */
   async startEditing(layerId, options = {}) {
     const toolbox = this.getToolBoxById(layerId);
+    //need to set selected toolbox before start editing to show scale constraint message related to layer
+    toolbox.setSelected(true);
     const data    = await toolbox.start(options);
     return data ? { toolbox, data } : toolbox;
   }


### PR DESCRIPTION
Project: https://webgis.bonificarenana.it/it/map/segnalazioni/qdjango/93/

If you try to use editing api startEditing method and a layer has a scale constraint, toolbox are not started without show scale contraint


<img width="1489" height="746" alt="Screenshot_20260511_150435" src="https://github.com/user-attachments/assets/97847f26-0386-4968-b33d-23c34ac9bf55" />

### Before

No message

<img width="1489" height="746" alt="Screenshot_20260511_150525" src="https://github.com/user-attachments/assets/7cbc3cbf-ad89-4af0-9772-31e07939e2a3" />


### After

<img width="1489" height="746" alt="Screenshot_20260511_150344" src="https://github.com/user-attachments/assets/37f93952-d06d-4115-a580-58b796b189fe" />
