### PR TITLE
Add search functionality for G3WSpatialRefSys admin using srid and auth_name fields

### DIFF
--- a/g3w-admin/core/admin.py
+++ b/g3w-admin/core/admin.py
@@ -71,6 +71,7 @@ admin.site.register(MapControl, MapControlAdmin)
 
 class G3WSpatialRefSysAdmin(ModelAdmin):
     model = G3WSpatialRefSys
+    search_fields = ('srid', 'auth_name')
 admin.site.register(G3WSpatialRefSys, G3WSpatialRefSysAdmin)
 
 


### PR DESCRIPTION
Closes: #1370 

This pull request introduces a minor improvement to the admin interface for spatial reference systems. The change adds search capabilities to the `G3WSpatialRefSysAdmin` class, making it easier for admins to find records by `srid` or `auth_name`.

* Added `search_fields` for `srid` and `auth_name` to the `G3WSpatialRefSysAdmin` class to improve searchability in the admin interface.
