### PR TITLE
Wrong editing form structure (ref: layer style)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ g3w-admin.code-workspace
 /g3w-admin/base/settings/local_settings.py.*
 /g3w-admin/base/settings/local_ldap_settings.py
 
+# Docker ovverides
+/g3w-admin/base/wsgi_docker.py
+
 # Node modules
 /node_modules
 

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1920,20 +1920,13 @@ export class ToolBox extends Emitter {
       );
       if (!is_started && GIVE_ME_A_NAME) {
         this.setEditing(true);
-        GUI.onceafter('setHidden', () => {
-          setTimeout(async () => {
-            this.#start = true;
-            this.startLoading();
-            this.setFeaturesOptions({ filter: options.filter });
-            try {
-              await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption));
-            } catch(e) {
-              reject(e);
-            } finally {
-              this.stopLoading();
-            }
-          }, 300);
-        });
+        const { promise, resolve: res } = Promise.withResolvers();
+        GUI.onceafter('setHidden', () => setTimeout(res, 300));
+        await promise;
+        this.#start = true;
+        this.startLoading();
+        this.setFeaturesOptions({ filter: options.filter });
+        await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption));
       }
 
       try {

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1817,6 +1817,7 @@ export class ToolBox extends Emitter {
    * @param { boolean } [options.disablemapcontrols=false]
    * @param { boolean } [options.showselectlayers=true]
    * @param { string }  [options.title]
+   * @param { Array }   [options.tools]
    * 
    * @returns { Promise<unknown> } info about start editing has features loaded
    */
@@ -1843,6 +1844,7 @@ export class ToolBox extends Emitter {
 
       this.state.changingtools = options.changingtools ?? false;
 
+      //show only some explicit tools for toolbox
       if (options.tools) {
         this.setEnablesDisablesTools(options.tools);
       }
@@ -1887,7 +1889,7 @@ export class ToolBox extends Emitter {
             }
           })
         );
-        // if click on start toolbox can edit
+        // if can editing layer, resolve
         if (this.state.editing.canEdit) {
           res();
         }
@@ -1899,24 +1901,23 @@ export class ToolBox extends Emitter {
         GUI.setModal(false);
       }
 
-      this.#startAsync = null;
+      this.#startAsync = null; //reset #startAsync
 
-      this.setFeaturesOptions({ filter: options.filter });
+      this.setFeaturesOptions({ filter: options.filter }); //set filter options to get features (ex. bbox, fids, etc..)
 
-      const is_started = !!this.isSessionStarted();
+      const is_started = this.isSessionStarted(); //Boolean check if session, to get features, is started (already ge features)
 
-      //@TODO need to explain better
-      const GIVE_ME_A_NAME = (
+      //In case of mobile device with hidden map and vector layer when click on start editing
+      const isMobileHiddenMap = (
         ApplicationState.ismobile             // mobile device
         && GUI.isMapHidden()                  // map not visible (content 100%)
         && 'vector' === this.state._layerType // vector layer
       );
 
-      if (!is_started && GIVE_ME_A_NAME) {
-        this.setEditing(true);
+      this.startLoading();
+      //ina case toolbox is not yet started and we are in mobile with map hidden we need to start session before set editing to true to avoid conflict with map controls disabled when set editing true and map not visible
+      if (!is_started && isMobileHiddenMap) {
         await new Promise(res => GUI.onceafter('setHidden', () => setTimeout(res, 300))); // 300 = CSS transition?
-        this.#start = true;
-        this.startLoading();
         this.setFeaturesOptions({ filter: options.filter });
 
         this.emit('start-editing');
@@ -1924,28 +1925,23 @@ export class ToolBox extends Emitter {
         features = await this._session.start(this.state._getFeaturesOption);
       }
 
-      /** @TODO merge the following conditions? */
-      if (!is_started && !GIVE_ME_A_NAME) {
-        this.#start = true;
-        this.startLoading();
+      /** In case of not yest started session and is not in mobile */
+      if (!is_started && !isMobileHiddenMap) {
 
         this.emit('start-editing');
         await setLayerUniqueFieldValues(this.getId());
         features = await this._session.start(this.state._getFeaturesOption);
       }
 
+      /**
+       * Case of session already started to from parent layer to get features without start toolbox
+       */
       if (is_started && !this.#start) {
-        this.startLoading();
 
         this.emit('start-editing');
         await setLayerUniqueFieldValues(this.getId());
         features = await this._session.getFeatures(this.state._getFeaturesOption);
 
-        this.#start = true;
-      }
-
-      if (is_started) {
-        this.setEditing(true);
       }
 
       // disablemapcontrols in conflict
@@ -1961,7 +1957,11 @@ export class ToolBox extends Emitter {
       // force vector layer visibity when starting toolbox (eg. image layers whose catalog layer may be hidden)
       this.state.layer.getOLLayer?.()?.setVisible(true);
 
+      //set start
+      this.#start = true;
+      //stop loading
       this.stopLoading();
+      //set Editing to true
       this.setEditing(true);
 
       return { features };
@@ -2780,7 +2780,7 @@ export class ToolBox extends Emitter {
    * @since g3w-client-plugin-editing@v3.8.0
    */
   isSessionStarted() {
-    return this.state.editing.session.started;
+    return !!this.state.editing.session.started;
   }
 
   /**

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1910,6 +1910,7 @@ export class ToolBox extends Emitter {
       }
 
       const is_started = !!this.isSessionStarted();
+      
 
       //@TODO need to explain better
       const GIVE_ME_A_NAME = (
@@ -1924,13 +1925,7 @@ export class ToolBox extends Emitter {
             this.#start = true;
             this.startLoading();
             this.setFeaturesOptions({ filter: options.filter });
-            try {
-              resolve({ features: await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption)) });
-            } catch(e) {
-              console.warn(e);
-              this.setEditing(false);
-              reject(e);
-            }
+            await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption));
           }, 300);
         });
       }
@@ -1961,7 +1956,7 @@ export class ToolBox extends Emitter {
           await getCatalogLayerById(this.state.id).changeStyle(this.state.layer.config.editing.layer_style);
         }
 
-        // force vector layer visibility when starting toolbox (eg. image layers whose catalog layer may be hidden)
+        // force vector layer visibity when starting toolbox (eg. image layers whose catalog layer may be hidden)
         this.state.layer.getOLLayer?.()?.setVisible(true);
 
         this.stopLoading();
@@ -1977,8 +1972,6 @@ export class ToolBox extends Emitter {
         }
         this.stop();
         this.stopLoading();
-        this.setEditing(false);
-        reject(e);
       }
 
       

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1820,163 +1820,160 @@ export class ToolBox extends Emitter {
    * 
    * @returns { Promise<unknown> } info about start editing has features loaded
    */
-  start(options = {}) {
-    return new Promise(async (resolve, reject) => {
+  async start(options = {}) {
 
-      try {
-        // get current style of layer
-        this.#current_style = this.state.layer.getCurrentStyle().name;
+    try {
+      // get current style of layer
+      this.#current_style = this.state.layer.getCurrentStyle().name;
 
-        const plugin = GUI.getPlugin('editing');
-        const id     = this.getId();
+      const plugin = GUI.getPlugin('editing');
+      const id     = this.getId();
 
-        plugin.state.showselectlayers = options.showselectlayers ?? true;
-        plugin.state.toolboxselected  = (options.selected ?? true) ? this : plugin.state.toolboxselected;
+      plugin.state.showselectlayers = options.showselectlayers ?? true;
+      plugin.state.toolboxselected  = (options.selected ?? true) ? this : plugin.state.toolboxselected;
 
-        const constraints = plugin.state.constraints.toolboxes[id];
+      const constraints = plugin.state.constraints.toolboxes[id];
 
-        // set title
-        if (undefined !== options.title) {
-          this.setTitle(options.title);
-        }
-
-        this.state.changingtools = options.changingtools ?? false;
-
-        if (options.tools) {
-          this.setEnablesDisablesTools(options.tools);
-        }
-
-        this.state.toolboxheader    = options.toolboxheader ?? true;
-        this.state.startstopediting = options.startstopediting ?? true;
-    
-        options.filter = constraints?.filter || this.constraints.filter || options.filter;
-
-        // register lock features to show a message
-        const unKeyLock = this._editor.onceafter('featuresLockedByOtherUser', () => {
-          GUI.showUserMessage({
-            type:     'warning',
-            subtitle: this.state.layer.getName().toUpperCase(),
-            message:  'plugins.editing.messages.featureslockbyotheruser',
-          })
-        });
-    
-        // add featuresLockedByOtherUser setter
-        this.state._unsetters.push(() => this._editor.un('featuresLockedByOtherUser', unKeyLock));
-
-        // check if can we edit based on scale contraint (vector layer)
-        if (this.state._constraints.scale) {
-          const { promise, resolve: res, reject: rej } = Promise.withResolvers();
-          this.state.editing.canEdit = false;
-          // reset user message scale (on stop)
-          this.state._unsetters.push(() => this._handleScaleConstraint());
-          // set as resolve handler to resolve waiting get features from server
-          this.#startAsync = res;
-          // listen selected attribute
-          this.state._unsetters.push(Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true }));
-          // await scale set for get features
-          this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint()), 600));
-          // click to fit zoom scale constraint
-          this.#events.push(
-            GUI.getMap().on('click', e => {
-              if (this.state.selected && !this.state.editing.canEdit) {
-                GUI.getMap().getView().animate(
-                  { duration: 200, center: e.coordinate },
-                  { duration: 200, resolution: getResolutionFromScale(this.state._constraints.scale, GUI.getMapUnits()) || GUI.getMap().getView().getResolution() }
-                );
-              }
-            })
-          );
-          // if click on start toolbox can edit
-          if (this.state.editing.canEdit) {
-            res();
-          }
-          await promise;
-        }
-
-        // reset eventually message
-        if (!this.state._constraints.scale) {
-          GUI.setModal(false);
-        }
-
-        this.#startAsync = null;
-
-        this.setFeaturesOptions({ filter: options.filter });
-        let features;
-
-        const handlerAfterSessionGetFeatures = async promise => {
-          this.emit('start-editing');
-          // set unique fields values
-          await setLayerUniqueFieldValues(this.getId());
-          features = await promise;
-          return features;
-        }
-
-        const is_started = !!this.isSessionStarted();
-        
-
-        //@TODO need to explain better
-        const GIVE_ME_A_NAME = (
-          ApplicationState.ismobile // is mobile
-          && GUI.isMapHidden() // map is not visible (content 100%)
-          && 'vector' === this.state._layerType // is  vector
-        );
-        if (!is_started && GIVE_ME_A_NAME) {
-          this.setEditing(true);
-          const { promise, resolve: res } = Promise.withResolvers();
-          GUI.onceafter('setHidden', () => setTimeout(res, 300));
-          await promise;
-          this.#start = true;
-          this.startLoading();
-          this.setFeaturesOptions({ filter: options.filter });
-          await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption));
-        }
-
-        /** @TODO merge the following conditions? */
-        if (!is_started && !GIVE_ME_A_NAME) {
-          this.#start = true;
-          this.startLoading();
-          await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption))
-        }
-
-        if (is_started && !this.#start) {
-          this.startLoading();
-          await handlerAfterSessionGetFeatures(this._session.getFeatures(this.state._getFeaturesOption))
-          this.#start = true;
-        }
-
-        if (is_started) { this.setEditing(true); }
-
-        // disablemapcontrols in conflict
-        if (options.disablemapcontrols ?? false) {
-          GUI.disableClickMapControls(true);
-        }
-
-        // wait for features before changing editing layer style 
-        if (this.state.layer.config.editing.layer_style && this.#current_style !== this.state.layer.config.editing.layer_style) {
-          await getCatalogLayerById(this.state.id).changeStyle(this.state.layer.config.editing.layer_style);
-        }
-
-        // force vector layer visibity when starting toolbox (eg. image layers whose catalog layer may be hidden)
-        this.state.layer.getOLLayer?.()?.setVisible(true);
-
-        this.stopLoading();
-        this.setEditing(true);
-
-        resolve({ features });
-      } catch(e) {
-
-        console.warn(e);
-
-        if (!e.signal) {
-          GUI.showUserMessage({ type: 'alert', message: e.message });
-        }
-        
-        this.stop();
-        this.stopLoading();
-        reject(e);
+      // set title
+      if (undefined !== options.title) {
+        this.setTitle(options.title);
       }
 
-    });
+      this.state.changingtools = options.changingtools ?? false;
+
+      if (options.tools) {
+        this.setEnablesDisablesTools(options.tools);
+      }
+
+      this.state.toolboxheader    = options.toolboxheader ?? true;
+      this.state.startstopediting = options.startstopediting ?? true;
+  
+      options.filter = constraints?.filter || this.constraints.filter || options.filter;
+
+      // register lock features to show a message
+      const unKeyLock = this._editor.onceafter('featuresLockedByOtherUser', () => {
+        GUI.showUserMessage({
+          type:     'warning',
+          subtitle: this.state.layer.getName().toUpperCase(),
+          message:  'plugins.editing.messages.featureslockbyotheruser',
+        })
+      });
+  
+      // add featuresLockedByOtherUser setter
+      this.state._unsetters.push(() => this._editor.un('featuresLockedByOtherUser', unKeyLock));
+
+      // check if can we edit based on scale contraint (vector layer)
+      if (this.state._constraints.scale) {
+        const { promise, resolve: res, reject: rej } = Promise.withResolvers();
+        this.state.editing.canEdit = false;
+        // reset user message scale (on stop)
+        this.state._unsetters.push(() => this._handleScaleConstraint());
+        // set as resolve handler to resolve waiting get features from server
+        this.#startAsync = res;
+        // listen selected attribute
+        this.state._unsetters.push(Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true }));
+        // await scale set for get features
+        this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint()), 600));
+        // click to fit zoom scale constraint
+        this.#events.push(
+          GUI.getMap().on('click', e => {
+            if (this.state.selected && !this.state.editing.canEdit) {
+              GUI.getMap().getView().animate(
+                { duration: 200, center: e.coordinate },
+                { duration: 200, resolution: getResolutionFromScale(this.state._constraints.scale, GUI.getMapUnits()) || GUI.getMap().getView().getResolution() }
+              );
+            }
+          })
+        );
+        // if click on start toolbox can edit
+        if (this.state.editing.canEdit) {
+          res();
+        }
+        await promise;
+      }
+
+      // reset eventually message
+      if (!this.state._constraints.scale) {
+        GUI.setModal(false);
+      }
+
+      this.#startAsync = null;
+
+      this.setFeaturesOptions({ filter: options.filter });
+      let features;
+
+      const is_started = !!this.isSessionStarted();
+
+      //@TODO need to explain better
+      const GIVE_ME_A_NAME = (
+        ApplicationState.ismobile // is mobile
+        && GUI.isMapHidden() // map is not visible (content 100%)
+        && 'vector' === this.state._layerType // is  vector
+      );
+      if (!is_started && GIVE_ME_A_NAME) {
+        this.setEditing(true);
+        const { promise, resolve: res } = Promise.withResolvers();
+        GUI.onceafter('setHidden', () => setTimeout(res, 300));
+        await promise;
+        this.#start = true;
+        this.startLoading();
+        this.setFeaturesOptions({ filter: options.filter });
+
+        this.emit('start-editing');
+        await setLayerUniqueFieldValues(this.getId());
+        features = await this._session.start(this.state._getFeaturesOption);
+      }
+
+      /** @TODO merge the following conditions? */
+      if (!is_started && !GIVE_ME_A_NAME) {
+        this.#start = true;
+        this.startLoading();
+
+        this.emit('start-editing');
+        await setLayerUniqueFieldValues(this.getId());
+        features = await this._session.start(this.state._getFeaturesOption);
+      }
+
+      if (is_started && !this.#start) {
+        this.startLoading();
+
+        this.emit('start-editing');
+        await setLayerUniqueFieldValues(this.getId());
+        features = await this._session.getFeatures(this.state._getFeaturesOption);
+
+        this.#start = true;
+      }
+
+      if (is_started) {
+        this.setEditing(true);
+      }
+
+      // disablemapcontrols in conflict
+      if (options.disablemapcontrols ?? false) {
+        GUI.disableClickMapControls(true);
+      }
+
+      // wait for features before changing editing layer style 
+      if (this.state.layer.config.editing.layer_style && this.#current_style !== this.state.layer.config.editing.layer_style) {
+        await getCatalogLayerById(this.state.id).changeStyle(this.state.layer.config.editing.layer_style);
+      }
+
+      // force vector layer visibity when starting toolbox (eg. image layers whose catalog layer may be hidden)
+      this.state.layer.getOLLayer?.()?.setVisible(true);
+
+      this.stopLoading();
+      this.setEditing(true);
+
+      return { features };
+    } catch(e) {
+      console.warn(e);
+      if (!e.signal) {
+        GUI.showUserMessage({ type: 'alert', message: e.message });
+      }
+      this.stop();
+      this.stopLoading();
+      throw e;
+    }
   };
 
   /**

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1925,7 +1925,13 @@ export class ToolBox extends Emitter {
             this.#start = true;
             this.startLoading();
             this.setFeaturesOptions({ filter: options.filter });
-            await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption));
+            try {
+              await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption));
+            } catch(e) {
+              reject(e);
+            } finally {
+              this.stopLoading();
+            }
           }, 300);
         });
       }

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1822,114 +1822,115 @@ export class ToolBox extends Emitter {
    */
   start(options = {}) {
     return new Promise(async (resolve, reject) => {
-      // get current style of layer
-      this.#current_style = this.state.layer.getCurrentStyle().name;
-
-      const plugin = GUI.getPlugin('editing');
-      const id     = this.getId();
-
-      plugin.state.showselectlayers = options.showselectlayers ?? true;
-      plugin.state.toolboxselected  = (options.selected ?? true) ? this : plugin.state.toolboxselected;
-
-      const constraints = plugin.state.constraints.toolboxes[id];
-
-      // set title
-      if (undefined !== options.title) {
-        this.setTitle(options.title);
-      }
-
-      this.state.changingtools = options.changingtools ?? false;
-
-      if (options.tools) {
-        this.setEnablesDisablesTools(options.tools);
-      }
-
-      this.state.toolboxheader    = options.toolboxheader ?? true;
-      this.state.startstopediting = options.startstopediting ?? true;
-  
-      options.filter = constraints?.filter || this.constraints.filter || options.filter;
-
-      // register lock features to show a message
-      const unKeyLock = this._editor.onceafter('featuresLockedByOtherUser', () => {
-        GUI.showUserMessage({
-          type:     'warning',
-          subtitle: this.state.layer.getName().toUpperCase(),
-          message:  'plugins.editing.messages.featureslockbyotheruser',
-        })
-      });
-  
-      // add featuresLockedByOtherUser setter
-      this.state._unsetters.push(() => this._editor.un('featuresLockedByOtherUser', unKeyLock));
-
-      // check if can we edit based on scale contraint (vector layer)
-      if (this.state._constraints.scale) {
-        const { promise, resolve: res, reject: rej } = Promise.withResolvers();
-        this.state.editing.canEdit = false;
-        // reset user message scale (on stop)
-        this.state._unsetters.push(() => this._handleScaleConstraint());
-        // set as resolve handler to resolve waiting get features from server
-        this.#startAsync = res;
-        // listen selected attribute
-        this.state._unsetters.push(Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true }));
-        // await scale set for get features
-        this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint()), 600));
-        // click to fit zoom scale constraint
-        this.#events.push(
-          GUI.getMap().on('click', e => {
-            if (this.state.selected && !this.state.editing.canEdit) {
-              GUI.getMap().getView().animate(
-                { duration: 200, center: e.coordinate },
-                { duration: 200, resolution: getResolutionFromScale(this.state._constraints.scale, GUI.getMapUnits()) || GUI.getMap().getView().getResolution() }
-              );
-            }
-          })
-        );
-        // if click on start toolbox can edit
-        if (this.state.editing.canEdit) {
-          res();
-        }
-        await promise;
-      }
-
-      // reset eventually message
-      if (!this.state._constraints.scale) {
-        GUI.setModal(false);
-      }
-
-      this.#startAsync = null;
-
-      this.setFeaturesOptions({ filter: options.filter });
-      let features;
-
-      const handlerAfterSessionGetFeatures = async promise => {
-        this.emit('start-editing');
-        // set unique fields values
-        await setLayerUniqueFieldValues(this.getId());
-        features = await promise;
-        return features;
-      }
-
-      const is_started = !!this.isSessionStarted();
-      
-
-      //@TODO need to explain better
-      const GIVE_ME_A_NAME = (
-        ApplicationState.ismobile // is mobile
-        && GUI.isMapHidden() // map is not visible (content 100%)
-        && 'vector' === this.state._layerType // is  vector
-      );
-      if (!is_started && GIVE_ME_A_NAME) {
-        this.setEditing(true);
-        const { promise, resolve: res } = Promise.withResolvers();
-        GUI.onceafter('setHidden', () => setTimeout(res, 300));
-        await promise;
-        this.#start = true;
-        this.startLoading();
-        this.setFeaturesOptions({ filter: options.filter });
-        await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption));
-      }
 
       try {
+        // get current style of layer
+        this.#current_style = this.state.layer.getCurrentStyle().name;
+
+        const plugin = GUI.getPlugin('editing');
+        const id     = this.getId();
+
+        plugin.state.showselectlayers = options.showselectlayers ?? true;
+        plugin.state.toolboxselected  = (options.selected ?? true) ? this : plugin.state.toolboxselected;
+
+        const constraints = plugin.state.constraints.toolboxes[id];
+
+        // set title
+        if (undefined !== options.title) {
+          this.setTitle(options.title);
+        }
+
+        this.state.changingtools = options.changingtools ?? false;
+
+        if (options.tools) {
+          this.setEnablesDisablesTools(options.tools);
+        }
+
+        this.state.toolboxheader    = options.toolboxheader ?? true;
+        this.state.startstopediting = options.startstopediting ?? true;
+    
+        options.filter = constraints?.filter || this.constraints.filter || options.filter;
+
+        // register lock features to show a message
+        const unKeyLock = this._editor.onceafter('featuresLockedByOtherUser', () => {
+          GUI.showUserMessage({
+            type:     'warning',
+            subtitle: this.state.layer.getName().toUpperCase(),
+            message:  'plugins.editing.messages.featureslockbyotheruser',
+          })
+        });
+    
+        // add featuresLockedByOtherUser setter
+        this.state._unsetters.push(() => this._editor.un('featuresLockedByOtherUser', unKeyLock));
+
+        // check if can we edit based on scale contraint (vector layer)
+        if (this.state._constraints.scale) {
+          const { promise, resolve: res, reject: rej } = Promise.withResolvers();
+          this.state.editing.canEdit = false;
+          // reset user message scale (on stop)
+          this.state._unsetters.push(() => this._handleScaleConstraint());
+          // set as resolve handler to resolve waiting get features from server
+          this.#startAsync = res;
+          // listen selected attribute
+          this.state._unsetters.push(Vue.watch(() => this.state.selected, () => this._handleScaleConstraint(), { immediate: true }));
+          // await scale set for get features
+          this.#events.push(GUI.getMap().getView().on('change:resolution', debounce(() => this._handleScaleConstraint()), 600));
+          // click to fit zoom scale constraint
+          this.#events.push(
+            GUI.getMap().on('click', e => {
+              if (this.state.selected && !this.state.editing.canEdit) {
+                GUI.getMap().getView().animate(
+                  { duration: 200, center: e.coordinate },
+                  { duration: 200, resolution: getResolutionFromScale(this.state._constraints.scale, GUI.getMapUnits()) || GUI.getMap().getView().getResolution() }
+                );
+              }
+            })
+          );
+          // if click on start toolbox can edit
+          if (this.state.editing.canEdit) {
+            res();
+          }
+          await promise;
+        }
+
+        // reset eventually message
+        if (!this.state._constraints.scale) {
+          GUI.setModal(false);
+        }
+
+        this.#startAsync = null;
+
+        this.setFeaturesOptions({ filter: options.filter });
+        let features;
+
+        const handlerAfterSessionGetFeatures = async promise => {
+          this.emit('start-editing');
+          // set unique fields values
+          await setLayerUniqueFieldValues(this.getId());
+          features = await promise;
+          return features;
+        }
+
+        const is_started = !!this.isSessionStarted();
+        
+
+        //@TODO need to explain better
+        const GIVE_ME_A_NAME = (
+          ApplicationState.ismobile // is mobile
+          && GUI.isMapHidden() // map is not visible (content 100%)
+          && 'vector' === this.state._layerType // is  vector
+        );
+        if (!is_started && GIVE_ME_A_NAME) {
+          this.setEditing(true);
+          const { promise, resolve: res } = Promise.withResolvers();
+          GUI.onceafter('setHidden', () => setTimeout(res, 300));
+          await promise;
+          this.#start = true;
+          this.startLoading();
+          this.setFeaturesOptions({ filter: options.filter });
+          await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption));
+        }
+
         /** @TODO merge the following conditions? */
         if (!is_started && !GIVE_ME_A_NAME) {
           this.#start = true;
@@ -1969,12 +1970,11 @@ export class ToolBox extends Emitter {
         if (!e.signal) {
           GUI.showUserMessage({ type: 'alert', message: e.message });
         }
+        
         this.stop();
         this.stopLoading();
         reject(e);
       }
-
-      
 
     });
   };

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1961,7 +1961,7 @@ export class ToolBox extends Emitter {
           await getCatalogLayerById(this.state.id).changeStyle(this.state.layer.config.editing.layer_style);
         }
 
-        // force vector layer visibity when starting toolbox (eg. image layers whose catalog layer may be hidden)
+        // force vector layer visibility when starting toolbox (eg. image layers whose catalog layer may be hidden)
         this.state.layer.getOLLayer?.()?.setVisible(true);
 
         this.stopLoading();

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1972,6 +1972,7 @@ export class ToolBox extends Emitter {
         }
         this.stop();
         this.stopLoading();
+        reject(e);
       }
 
       

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1822,6 +1822,8 @@ export class ToolBox extends Emitter {
    */
   async start(options = {}) {
 
+    let features;
+
     try {
       // get current style of layer
       this.#current_style = this.state.layer.getCurrentStyle().name;
@@ -1900,21 +1902,19 @@ export class ToolBox extends Emitter {
       this.#startAsync = null;
 
       this.setFeaturesOptions({ filter: options.filter });
-      let features;
 
       const is_started = !!this.isSessionStarted();
 
       //@TODO need to explain better
       const GIVE_ME_A_NAME = (
-        ApplicationState.ismobile // is mobile
-        && GUI.isMapHidden() // map is not visible (content 100%)
-        && 'vector' === this.state._layerType // is  vector
+        ApplicationState.ismobile             // mobile device
+        && GUI.isMapHidden()                  // map not visible (content 100%)
+        && 'vector' === this.state._layerType // vector layer
       );
+
       if (!is_started && GIVE_ME_A_NAME) {
         this.setEditing(true);
-        const { promise, resolve: res } = Promise.withResolvers();
-        GUI.onceafter('setHidden', () => setTimeout(res, 300));
-        await promise;
+        await new Promise(res => GUI.onceafter('setHidden', () => setTimeout(res, 300))); // 300 = CSS transition?
         this.#start = true;
         this.startLoading();
         this.setFeaturesOptions({ filter: options.filter });

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1899,27 +1899,14 @@ export class ToolBox extends Emitter {
       this.#startAsync = null;
 
       this.setFeaturesOptions({ filter: options.filter });
+      let features;
 
       const handlerAfterSessionGetFeatures = async promise => {
         this.emit('start-editing');
         // set unique fields values
         await setLayerUniqueFieldValues(this.getId());
-        try {
-          const features = await promise;
-          this.stopLoading();
-          this.setEditing(true);
-          resolve({ features })
-        } catch(e) {
-          console.warn(e);
-          
-          if (!e.signal) {
-            GUI.showUserMessage({ type: 'alert', message: e.message });
-          }
-          
-          this.stop();
-          this.stopLoading();
-          reject(e);
-        }
+        features = await promise;
+        return features;
       }
 
       const is_started = !!this.isSessionStarted();
@@ -1938,42 +1925,61 @@ export class ToolBox extends Emitter {
             this.startLoading();
             this.setFeaturesOptions({ filter: options.filter });
             try {
-              await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption));
+              resolve({ features: await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption)) });
             } catch(e) {
               console.warn(e);
               this.setEditing(false);
+              reject(e);
             }
           }, 300);
         });
       }
 
-      /** @TODO merge the following conditions? */
-      if (!is_started && !GIVE_ME_A_NAME) {
-        this.#start = true;
-        this.startLoading();
-        await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption))
+      try {
+        /** @TODO merge the following conditions? */
+        if (!is_started && !GIVE_ME_A_NAME) {
+          this.#start = true;
+          this.startLoading();
+          await handlerAfterSessionGetFeatures(this._session.start(this.state._getFeaturesOption))
+        }
+
+        if (is_started && !this.#start) {
+          this.startLoading();
+          await handlerAfterSessionGetFeatures(this._session.getFeatures(this.state._getFeaturesOption))
+          this.#start = true;
+        }
+
+        if (is_started) { this.setEditing(true); }
+
+        // disablemapcontrols in conflict
+        if (options.disablemapcontrols ?? false) {
+          GUI.disableClickMapControls(true);
+        }
+
+        // wait for features before changing editing layer style 
+        if (this.state.layer.config.editing.layer_style && this.#current_style !== this.state.layer.config.editing.layer_style) {
+          await getCatalogLayerById(this.state.id).changeStyle(this.state.layer.config.editing.layer_style);
+        }
+
+        // force vector layer visibity when starting toolbox (eg. image layers whose catalog layer may be hidden)
+        this.state.layer.getOLLayer?.()?.setVisible(true);
+
+        this.stopLoading();
+        this.setEditing(true);
+
+        resolve({ features });
+      } catch(e) {
+
+        console.warn(e);
+
+        if (!e.signal) {
+          GUI.showUserMessage({ type: 'alert', message: e.message });
+        }
+        this.stop();
+        this.stopLoading();
       }
 
-      if (is_started && !this.#start) {
-        this.startLoading();
-        await handlerAfterSessionGetFeatures(this._session.getFeatures(this.state._getFeaturesOption))
-        this.#start = true;
-      }
-
-      if (is_started) { this.setEditing(true); }
-
-      // disablemapcontrols in conflict
-      if (options.disablemapcontrols ?? false) {
-        GUI.disableClickMapControls(true);
-      }
-
-      // wait for features before changing editing layer style 
-      if (this.state.layer.config.editing.layer_style && this.#current_style !== this.state.layer.config.editing.layer_style) {
-        await getCatalogLayerById(this.state.id).changeStyle(this.state.layer.config.editing.layer_style);
-      }
-
-      // force vector layer visibity when starting toolbox (eg. image layers whose catalog layer may be hidden)
-      this.state.layer.getOLLayer?.()?.setVisible(true);
+      
 
     });
   };

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1977,6 +1977,8 @@ export class ToolBox extends Emitter {
         }
         this.stop();
         this.stopLoading();
+        this.setEditing(false);
+        reject(e);
       }
 
       

--- a/g3w-admin/editing/static/editing/js/index.js
+++ b/g3w-admin/editing/static/editing/js/index.js
@@ -1166,7 +1166,7 @@ new (class extends Plugin {
     if (undefined === fid) { return }
 
     this.getToolBoxes().forEach(tb => tb.setShow(layer.id === tb.getId()));
-    this.showEditingPanel();
+    await this.showEditingPanel();
 
     this.state.showselectlayers = false;
 
@@ -1192,7 +1192,6 @@ new (class extends Plugin {
         if (currentScale > scale) {
           map.getView().setResolution(getResolutionFromScale(scale, units));
         }
-
       }
 
       await toolBox.start({ filter: { fids: fid } });
@@ -1214,8 +1213,13 @@ new (class extends Plugin {
 
       const geom = feature.getGeometry();
 
-      // feature has geometry → zoom to geometry
-      if (geom) {
+      // feature has geometry and scale constraint → set map center
+      if (geom && scale) {
+        GUI.getMap().getView().setCenter(ol.extent.getCenter(geom?.getExtent()));
+      }
+
+      //if feature has geometry and not a scale constraint → zoom feature extent
+      if (geom && !scale) {
         GUI.zoomToExtent(geom?.getExtent());
       }
 
@@ -1288,6 +1292,7 @@ new (class extends Plugin {
         helpMessage: 'editing.tools.update_feature',
         steps:       [ new (await import('./actions/open-form.js')).OpenFormStep() ]
       }));
+
 
       await w.start({
         inputs:  { layer: _layer, features: [feature] },


### PR DESCRIPTION
### Issue description

Editing form structure did not dynamically update when changing the layer style (e.g., from Categorized to Graduated). 

Fixes: https://gitlab.gis3w.it/gis3w/bonifica-renana/-/work_items/79

### How to test

0. Go to: https://dev.g3wsuite.it/en/map/g3w-suite-demo/qdjango/97/
1. Query a **Building**  feature on map(starts with *Categorized* style)
2. Click **Edit feature** <img width="36" height="44" alt="Screenshot_20260521_141839" src="https://github.com/user-attachments/assets/d85bbce1-8303-414f-8b26-4cf79df71d2a" />

### Expected behavior

The form layout must update and adapt to the *Graduated* style.

**Query result:**

<img width="1915" height="700" alt="Screenshot_20260521_142047" src="https://github.com/user-attachments/assets/10967771-e68b-4752-bbec-441f2cd757e3" />


**Editing form:**

<img width="1267" height="1038" alt="Screenshot_20260521_114413" src="https://github.com/user-attachments/assets/d657aa8a-aea5-43e5-b09d-796265a60b59" />
