### PR TITLE
refactor: update logout URL handling to use settings variable

### DIFF
--- a/g3w-admin/about/api/serializers.py
+++ b/g3w-admin/about/api/serializers.py
@@ -190,7 +190,7 @@ class GenericSuiteDataSerializer(GetUnlanguageFieldsMixin, serializers.ModelSeri
         login_url = getattr(settings, 'LOGIN_URL')
         if login_url:
             ret['login_url'] = settings.LOGIN_URL
-            ret['logout_url'] = reverse('logout')
+            ret['logout_url'] = getattr(settings, 'LOGOUT_URL', 'logout')
 
         return ret
 

--- a/g3w-admin/base/settings/base.py
+++ b/g3w-admin/base/settings/base.py
@@ -188,6 +188,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 
 LOGIN_URL = 'login'
+LOGOUT_URL = 'logout'
 LOGOUT_NEXT_PAGE = '/'
 LOGIN_REDIRECT_URL = '/'
 

--- a/g3w-admin/client/views.py
+++ b/g3w-admin/client/views.py
@@ -120,7 +120,7 @@ class ClientView(TemplateView):
         # logout_url
         logout_url = None
         try:
-            logout_url = reverse('logout') + '?next={}'.format(reverse('group-project-map', kwargs={
+            logout_url = resolve_url(settings.LOGOUT_URL) + '?next={}'.format(reverse('group-project-map', kwargs={
                 'group_slug': kwargs['group_slug'],
                 'project_type': kwargs['project_type'],
                 'project_id': self.project.pk

--- a/g3w-admin/templates/include/navbar_right_menu.html
+++ b/g3w-admin/templates/include/navbar_right_menu.html
@@ -54,7 +54,7 @@
                         <a href="{% url 'user-update' user.pk %}" class="btn btn-default btn-flat"><i class="fa fa-folder"></i> {% trans 'Profile' %}</a>
                     </div>
                     <div class="pull-right">
-                        <a href="{% url 'logout' %}{% if SETTINGS.FRONTEND %}?next={% url 'frontend' %}{% endif %}" class="btn btn-default btn-flat"><i class="fa fa-sign-out"></i> {% trans 'Logout' %}</a>
+                        <a href="{% url SETTINGS.LOGOUT_URL %}{% if SETTINGS.FRONTEND %}?next={% url 'frontend' %}{% endif %}" class="btn btn-default btn-flat"><i class="fa fa-sign-out"></i> {% trans 'Logout' %}</a>
                     </div>
                 </li>
             </ul>


### PR DESCRIPTION
This pull request standardizes the use of the logout URL across the codebase by introducing a `LOGOUT_URL` setting and updating all references to use this setting instead of hardcoding or reversing the `'logout'` route directly. This makes the logout functionality more configurable and consistent.

**Settings and configuration:**
* Added `LOGOUT_URL = 'logout'` to the settings in `base.py` to centralize the logout route configuration.

**Codebase updates to use the new setting:**
* Updated the serializer in `about/api/serializers.py` to use `getattr(settings, 'LOGOUT_URL', 'logout')` instead of reversing the `'logout'` route directly, making it respect the configurable setting.
* Changed the logout URL resolution in `client/views.py` to use `resolve_url(settings.LOGOUT_URL)` for generating the logout link, ensuring consistency with the new setting.
* Modified the logout link in the navbar template to use `{% url SETTINGS.LOGOUT_URL %}` instead of hardcoding `'logout'`, so the template also respects the setting.
