### PR TITLE
Fix: correct validation message for scale limits in scalevisconstraintManagerList

### DIFF
--- a/g3w-admin/qdjango/static/qdjango/js/data-widget-scalevisconstraintManagerList.js
+++ b/g3w-admin/qdjango/static/qdjango/js/data-widget-scalevisconstraintManagerList.js
@@ -122,14 +122,14 @@ export async function scalevisconstraintManagerList($datatable, $item, refresh) 
                   <div class="form-group">
                     <label class="control-label ">${gettext("Min scale")}</label>
                     <div class="controls ">
-                      <input class="form-control" type="number" value="${SAVED_CONSTRAINT?.minscale ?? ''}" required name="minscale" />
+                      <input class="form-control" type="number" value="${SAVED_CONSTRAINT?.minscale ?? ''}" min="0" required name="minscale" />
                     </div>
                   </div>
 
                   <div class="form-group">
                     <label class="control-label ">${gettext("Max scale")}</label>
                     <div class="controls ">
-                      <input class="form-control" type="number" value="${SAVED_CONSTRAINT?.maxscale ?? ''}" required name="maxscale" />
+                      <input class="form-control" type="number" value="${SAVED_CONSTRAINT?.maxscale ?? ''}" min="0" required name="maxscale" />
                     </div>
                   </div>
 
@@ -147,13 +147,15 @@ export async function scalevisconstraintManagerList($datatable, $item, refresh) 
 
         modal.$modal.find('.modal-button-confirm').on('click', function (e) {
           let dt = form.getData("array");
+          console.log(dt);
 
           // Validate
           form.$form.find(".form-errors").html(`
-            ${ '' == dt.user && '' == dt.group        ? `<h4 class="badge bg-red">${gettext("You must select a 'group' or a 'user'!")}</h4>`: '' }
-            ${ '' != dt.user && '' != dt.group        ? `<h4 class="badge bg-red">${gettext("You cannot select both a 'group' and a 'user': they are mutually exclusive!")}</h4>`: '' }
-            ${ '' == dt.minscale || '' == dt.maxscale ? `<h4 class="badge bg-red">${gettext("The 'maxscale' and/or 'minscale' fields cannot be empty!")}</h4>` : '' }
-            ${ dt.minscale < dt.maxscale ? `<h4 class="badge bg-red">${gettext("The 'maxscale' can not be greater than the 'minscale'!")}</h4>` : '' }
+            ${ '' === dt.user && '' === dt.group                      ? `<h4 class="badge bg-red">${gettext("You must select a 'group' or a 'user'!")}</h4>` : '' }
+            ${ '' !== dt.user && '' !== dt.group                      ? `<h4 class="badge bg-red">${gettext("You cannot select both a 'group' and a 'user': they are mutually exclusive!")}</h4>` : '' }
+            ${ '' === dt.minscale || '' === dt.maxscale               ? `<h4 class="badge bg-red">${gettext("The 'maxscale' and/or 'minscale' fields cannot be empty!")}</h4>` : '' }
+            ${ (Number(dt.minscale) < 0 || Number(dt.maxscale) < 0)   ? `<h4 class="badge bg-red">${gettext("The 'minscale' and 'maxscale' values cannot be negative!")}</h4>` : '' }
+            ${ (Number(dt.minscale) < Number(dt.maxscale))            ? `<h4 class="badge bg-red">${gettext("The 'maxscale' can not be greater than the 'minscale'!")}</h4>` : '' }
           `);
 
           if (!form.$form.find(".form-errors").children().length) {
@@ -161,10 +163,10 @@ export async function scalevisconstraintManagerList($datatable, $item, refresh) 
           }
         });
 
-        modal.show()
+        modal.show();
 
-        modal.$modal.find('[name="user"]').select2()
-        modal.$modal.find('[name="group"]').select2()
+        modal.$modal.find('[name="user"]').select2();
+        modal.$modal.find('[name="group"]').select2();
       }
 
       // DELETE constraint

--- a/g3w-admin/qdjango/static/qdjango/js/data-widget-scalevisconstraintManagerList.js
+++ b/g3w-admin/qdjango/static/qdjango/js/data-widget-scalevisconstraintManagerList.js
@@ -153,7 +153,7 @@ export async function scalevisconstraintManagerList($datatable, $item, refresh) 
             ${ '' == dt.user && '' == dt.group        ? `<h4 class="badge bg-red">${gettext("You must select a 'group' or a 'user'!")}</h4>`: '' }
             ${ '' != dt.user && '' != dt.group        ? `<h4 class="badge bg-red">${gettext("You cannot select both a 'group' and a 'user': they are mutually exclusive!")}</h4>`: '' }
             ${ '' == dt.minscale || '' == dt.maxscale ? `<h4 class="badge bg-red">${gettext("The 'maxscale' and/or 'minscale' fields cannot be empty!")}</h4>` : '' }
-            ${ dt.minscale > dt.maxscale ? `<h4 class="badge bg-red">${gettext("The 'minscale' can not be greater than the 'maxscale'!")}</h4>` : '' }
+            ${ dt.minscale < dt.maxscale ? `<h4 class="badge bg-red">${gettext("The 'maxscale' can not be greater than the 'minscale'!")}</h4>` : '' }
           `);
 
           if (!form.$form.find(".form-errors").children().length) {


### PR DESCRIPTION
Closes: #1386 

This pull request fixes a validation logic error in the scale visibility constraint manager. The comparison for minscale and maxscale was reversed, which could result in incorrect error messages being shown to users.

<img width="629" height="551" alt="Screenshot_20260529_083153" src="https://github.com/user-attachments/assets/01a3693a-8cea-45e5-9a5e-4d7c8dac4cbb" />

Validation logic fix:

* Corrected the validation so that the error message is shown when `maxscale` is greater than `minscale`, instead of the previous (incorrect) check for `minscale` being greater than `maxscale` in `scalevisconstraintManagerList` in `qdjango/js/data-widget-scalevisconstraintManagerList.js`.
