### PR TITLE
Editor2 grants

### DIFF
--- a/g3w-admin/core/templates/core/ajax/group_detail.html
+++ b/g3w-admin/core/templates/core/ajax/group_detail.html
@@ -14,14 +14,14 @@
       <li><strong>{%trans 'Panoramic max scale'%}</strong>: {{ object.panoramic_max_scale }}</li>
       <li><strong>{%trans 'Panoramic min scale'%}</strong>: {{ object.panoramic_min_scale }}</li>
     </ul>
-    {%if user.is_superuser or user|has_group:"Editor Maps Groups" %}
+    {%if user.is_superuser or user|has_group:"Editor Maps Groups" or user|has_group:G3W_EDITOR1 or user|has_group:G3W_EDITOR2 %}
     	<h3>{%trans 'Users' %}:</h3>
     	<ul class="list-unstyled">
-    	{% if user.is_superuser %}
+    	{% if user.is_superuser or user|has_group:G3W_EDITOR1 or user|has_group:G3W_EDITOR2 %}
     		<li><strong>{%trans 'Editor level 1 user'%}</strong>: {{object.editor1|safe}}</li>
     	{% endif %}
 
-    	{% if user.is_superuser or user|has_group:"Editor Maps Groups" %}
+    	{% if user.is_superuser or user|has_group:"Editor Maps Groups" or user|has_group:G3W_EDITOR1 or user|has_group:G3W_EDITOR2 %}
             <li><strong>{%trans 'Editor level 2 user'%}</strong>: {{object.editor2|safe}}</li>
     		<li><strong>{%trans 'Viewer users'%}</strong>: {{object.viewers|safeseq|join:", "}}</li>
             <li><strong>{%trans 'Editor user groups'%}</strong>: {{object.editor_user_groups|safeseq|join:", "}}</li>

--- a/g3w-admin/core/templates/core/project_list.html
+++ b/g3w-admin/core/templates/core/project_list.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block custom_js_links_page %}
-{% if user.is_superuser or user|has_group:'Editor Level 1' or user|has_group:'Editor Level 2' %}
+{% if user.is_superuser or user|has_group:G3W_EDITOR1 or user|has_group:G3W_EDITOR2 %}
 <script>
 
     $( document ).ajaxComplete(function() {

--- a/g3w-admin/core/templates/core/project_list.html
+++ b/g3w-admin/core/templates/core/project_list.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block custom_js_links_page %}
-{% if user.is_superuser %}
+{% if user.is_superuser or user|has_group:'Editor Level 1' or user|has_group:'Editor Level 2' %}
 <script>
 
     $( document ).ajaxComplete(function() {

--- a/g3w-admin/qdjango/templates/qdjango/ajax/project_detail.html
+++ b/g3w-admin/qdjango/templates/qdjango/ajax/project_detail.html
@@ -13,13 +13,13 @@
             <div class="box-body">
                 <div class="row">
                     <div class="col-md-6">
-                        {%if user.is_superuser %}
+                        {% if user.is_superuser or user|has_group:"Editor Level 1" or user|has_group:"Editor Level 2" %}
                         <h3>{%trans 'Users' %}:</h3>
                         <ul class="list-unstyled">
                             {% if user.is_superuser %}
                                 <li><strong>{%trans 'Editor level 1 user'%}</strong>: {% if object.editor %}{{object.editor|safe}}{% endif %}</li>
                             {% endif %}
-                            {% if user.is_superuser or user|has_group:"Editor Maps Groups" %}
+                            {% if user.is_superuser or user|has_group:"Editor Maps Groups" or user|has_group:"Editor Level 1" or user|has_group:"Editor Level 2" %}
                                 <li><strong>{%trans 'Editor level 2 user'%}</strong>: {% if object.editor2 %}{{object.editor2|safe}}{% endif %}</li>
                                 <li><strong>{%trans 'Viewer users'%}</strong>: {{object.viewers|safeseq|join:", "}}</li>
                                 <li><strong>{%trans 'Editor user groups'%}</strong>: {{object.editor_user_groups|safeseq|join:", "}}</li>

--- a/g3w-admin/qdjango/templates/qdjango/ajax/project_detail.html
+++ b/g3w-admin/qdjango/templates/qdjango/ajax/project_detail.html
@@ -13,13 +13,13 @@
             <div class="box-body">
                 <div class="row">
                     <div class="col-md-6">
-                        {% if user.is_superuser or user|has_group:"Editor Level 1" or user|has_group:"Editor Level 2" %}
+                        {% if user.is_superuser or user|has_group:G3W_EDITOR1 or user|has_group:G3W_EDITOR2 %}
                         <h3>{%trans 'Users' %}:</h3>
                         <ul class="list-unstyled">
                             {% if user.is_superuser %}
                                 <li><strong>{%trans 'Editor level 1 user'%}</strong>: {% if object.editor %}{{object.editor|safe}}{% endif %}</li>
                             {% endif %}
-                            {% if user.is_superuser or user|has_group:"Editor Maps Groups" or user|has_group:"Editor Level 1" or user|has_group:"Editor Level 2" %}
+                            {% if user.is_superuser or user|has_group:"Editor Maps Groups" or user|has_group:G3W_EDITOR1 or user|has_group:G3W_EDITOR2 %}
                                 <li><strong>{%trans 'Editor level 2 user'%}</strong>: {% if object.editor2 %}{{object.editor2|safe}}{% endif %}</li>
                                 <li><strong>{%trans 'Viewer users'%}</strong>: {{object.viewers|safeseq|join:", "}}</li>
                                 <li><strong>{%trans 'Editor user groups'%}</strong>: {{object.editor_user_groups|safeseq|join:", "}}</li>

--- a/g3w-admin/qdjango/views/projects.py
+++ b/g3w-admin/qdjango/views/projects.py
@@ -1004,8 +1004,9 @@ class ProjectSetOrderView(View):
 
     model = Project
 
-    # only user with change_group for this group can change overview map.
-    @method_decorator(user_passes_test_or_403(lambda u: u.is_superuser))
+    # only user with change_project permission on the project can change order.
+    @method_decorator(permission_required('qdjango.change_project', (Project, 'pk', 'project_id'),
+                                          raise_exception=True))
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 


### PR DESCRIPTION
Closes: #1392 

This pull request expands permissions for users in certain groups and refines access control for project ordering. The main changes are focused on allowing users in "Editor Level 1" and "Editor Level 2" groups to access features previously limited to superusers, and updating the permission check for changing project order to use a more granular, object-level permission.

**Expanded group-based permissions:**

* Users in the "Editor Level 1" and "Editor Level 2" groups now have access to custom JavaScript features on the project list page, previously restricted to superusers.
* The same groups can now view user details in the project detail view, aligning their permissions with superusers for this section.
* The logic for displaying editor and viewer user lists has been updated to include "Editor Level 1" and "Editor Level 2" groups, in addition to "Editor Maps Groups".

**Improved access control for project ordering:**

* The `ProjectSetOrderView` now requires the `change_project` permission on the specific project object, rather than only allowing superusers, providing more precise and secure access control.
