### PR TITLE
Add overwrite option to AutoSlugField in MacroGroup and Group models

### DIFF
--- a/g3w-admin/core/models.py
+++ b/g3w-admin/core/models.py
@@ -102,7 +102,7 @@ class MacroGroup(TimeStampedModel, OrderedModel):
     use_logo_client = models.BooleanField(_('Use logo image for client'), default=False)
 
     slug = AutoSlugField(
-        _('Slug'), unique=True, populate_from=['name'])
+        _('Slug'), unique=True, populate_from=['name'], overwrite=True)
 
     def __str__(self):
         return self.title
@@ -137,7 +137,7 @@ class Group(TimeStampedModel, OrderedModel):
     title = models.CharField(_('Title'), max_length=255)
     description = models.TextField(_('Description'), blank=True)
     slug = AutoSlugField(
-        _('Slug'), populate_from=['name'], unique=True
+        _('Slug'), populate_from=['name'], unique=True, overwrite=True
         )
     is_active = models.BooleanField(_('Is active'), default=1)
 


### PR DESCRIPTION
This pull request updates the slug generation behavior for the `MacroGroup` and `Group` models. The most significant change is enabling the `overwrite` option for the `AutoSlugField`, ensuring that slugs are updated if the source field changes.

**Model field improvements:**

* [`g3w-admin/core/models.py`](diffhunk://#diff-b6a74296abca76409ca7d857efde85b92d0451aebc5bbb57249bc641ac92731fL105-R105): Set `overwrite=True` on the `slug` field for both the `MacroGroup` and `Group` models, so the slug is regenerated when the `name` changes. [[1]](diffhunk://#diff-b6a74296abca76409ca7d857efde85b92d0451aebc5bbb57249bc641ac92731fL105-R105) [[2]](diffhunk://#diff-b6a74296abca76409ca7d857efde85b92d0451aebc5bbb57249bc641ac92731fL140-R140)
