### PR TITLE
Fix: URL-decode field_value in FieldFilterBackend to handle URL parameters correctly

### DIFF
--- a/g3w-admin/core/api/filters.py
+++ b/g3w-admin/core/api/filters.py
@@ -325,6 +325,10 @@ class FieldFilterBackend(BaseFilterBackend):
 
                 # Make lowercase field_operator
                 field_operator = field_operator.lower()
+
+                # URL-decode field_value (it is passed as a URL parameter)
+                field_value = unquote(field_value)
+
                 if not self._is_valid_field(qgis_layer, field_name):
                     raise Exception(
                         f"{field_name} doesn't belong from layer {qgis_layer.name()}!")


### PR DESCRIPTION
This pull request introduces a small but important improvement to the `apply_filter` method in `g3w-admin/core/api/filters.py`. The change ensures that filter values passed as URL parameters are properly decoded before further processing, which helps prevent issues caused by encoded characters in filter values.

* The `field_value` is now URL-decoded using `unquote` to handle encoded characters in filter values passed via URL parameters.
