### PR TITLE
Add rulelabel option to BASE_G3W_CLIENT_LEGEND for automatic labeling

### DIFF
--- a/g3w-admin/base/settings/base_layout_settings.py
+++ b/g3w-admin/base/settings/base_layout_settings.py
@@ -14,4 +14,5 @@ G3W_CLIENT_RIGHT_PANEL = {
 
 BASE_G3W_CLIENT_LEGEND = {
    'transparent': True,
+   "rulelabel": "auto",
 }


### PR DESCRIPTION
This pull request makes a small update to the `BASE_G3W_CLIENT_LEGEND` settings by adding an automatic rule labeling option. This change introduces the `"rulelabel": "auto"` key to the legend configuration.
