### PR TITLE
Fallback for `"search.name"`

### DIFF
--- a/g3w-admin/client/api/views.py
+++ b/g3w-admin/client/api/views.py
@@ -81,9 +81,10 @@ class ClientConfigApiView(APIView):
 
         # Fallback for "search.name" (← "search.options.title")
         for search in ps.data.get("search", []):
-            title = search.get("options", {}).get("title", "")
-            if title:
-                search["name"] = title
+            if not search.get("name"):
+                title = search.get("options", {}).get("title", "")
+                if title:
+                    search["name"] = title
 
         # signal after serialization project
         ps_data = ps.data

--- a/g3w-admin/client/api/views.py
+++ b/g3w-admin/client/api/views.py
@@ -79,6 +79,12 @@ class ClientConfigApiView(APIView):
         if "onlineresource" in ps.data["metadata"]:
             del ps.data["metadata"]["onlineresource"]
 
+        # Fallback for "search.name" (← "search.options.title")
+        for search in ps.data.get("search", []):
+            title = search.get("options", {}).get("title", "")
+            if title:
+                search["name"] = title
+
         # signal after serialization project
         ps_data = ps.data
         for signal_receiver, data in post_serialize_project.send(

--- a/g3w-admin/client/api/views.py
+++ b/g3w-admin/client/api/views.py
@@ -81,10 +81,9 @@ class ClientConfigApiView(APIView):
 
         # Fallback for "search.name" (← "search.options.title")
         for search in ps.data.get("search", []):
-            if not search.get("name"):
-                title = search.get("options", {}).get("title", "")
-                if title:
-                    search["name"] = title
+            title = search.get("options", {}).get("title", "")
+            if title:
+                search["name"] = title
 
         # signal after serialization project
         ps_data = ps.data

--- a/g3w-admin/client/tests/test_api.py
+++ b/g3w-admin/client/tests/test_api.py
@@ -650,7 +650,7 @@ class ClientApiTest(CoreTestBase):
 
         self.assertTrue(len(resp["search"]) > 0)
         resp_serach = resp['search'][0]
-        self.assertEqual(resp_serach['name'], 'Test selectbox')
+        self.assertEqual(resp_serach['name'], 'asert')
         self.assertEqual(resp_serach['type'], 'search')
         self.assertEqual(resp_serach['options']['filter'][0]['input']['type'], 'selectfield')
         # removed in v3.8
@@ -699,7 +699,7 @@ class ClientApiTest(CoreTestBase):
 
         self.assertTrue(len(resp["search"]) == 2)
         resp_serach = resp['search'][1]
-        self.assertEqual(resp_serach['name'], 'Test autocompletebox')
+        self.assertEqual(resp_serach['name'], 'autocomplete test title')
         self.assertEqual(resp_serach['type'], 'search')
         self.assertEqual(resp_serach['options']['filter'][0]['input']['type'], 'autocompletefield')
         self.assertEqual(resp_serach['options']['filter'][0]['logicop'], 'AND')
@@ -747,7 +747,7 @@ class ClientApiTest(CoreTestBase):
 
         self.assertTrue(len(resp["search"]) > 0)
         resp_serach = resp['search'][0]
-        self.assertEqual(resp_serach['name'], 'Test selectbox for field with valuemap')
+        self.assertEqual(resp_serach['name'], 'asert')
         self.assertEqual(resp_serach['type'], 'search')
         self.assertEqual(resp_serach['options']['filter'][0]['input']['type'], 'selectfield')
         # removed in v3.8


### PR DESCRIPTION
Supersedes: https://github.com/g3w-suite/g3w-client/pull/956

Project https://dev.g3wsuite.it/en/map/g3w-suite-demo/qdjango/97/

<img width="991" height="275" alt="Screenshot_20260618_151309" src="https://github.com/user-attachments/assets/59124f77-3ca5-4448-b6df-a29771f7960a" />


### Before

<img width="991" height="275" alt="Screenshot_20260618_151335" src="https://github.com/user-attachments/assets/72a0f0d0-c8bc-4d0f-abea-1507c2c1629f" />

<img width="392" height="275" alt="Screenshot_20260618_151407" src="https://github.com/user-attachments/assets/9320e8b0-2f98-4865-b034-8bf46ded3f3c" />


### After

<img width="392" height="275" alt="Screenshot_20260618_151427" src="https://github.com/user-attachments/assets/2b71191c-c3b2-426d-96ea-d5381185019a" />


<img width="392" height="275" alt="Screenshot_20260618_151449" src="https://github.com/user-attachments/assets/8709439d-6f07-4562-811c-133c2e577c19" />

