### PR TITLE
Enhance login error handling to display specific messages for invalidlogin attempts

### DIFF
--- a/g3w-admin/templates/login.html
+++ b/g3w-admin/templates/login.html
@@ -22,7 +22,17 @@
       <div class="alert alert-danger alert-dismissible">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
         <h4><i class="icon fa fa-ban"></i> {% trans 'LOGIN ERROR' %}!</h4>
-        {% trans 'Username and/or password uncorrect' %}
+        {% if form.non_field_errors %}
+          {% for err in form.non_field_errors.as_data %}
+            {% if err.code == 'invalid_login' %}
+              <div>{% trans 'Username and/or password uncorrect' %}</div>
+            {% else %}
+              <div>{{ err.message }}</div>
+            {% endif %}
+          {% endfor %}
+        {% else %}
+          {% trans 'Username and/or password uncorrect' %}
+        {% endif %}
       </div>
       {% endif %}
       {% if SETTINGS.ENABLE_TWO_FACTOR_AUTH %}


### PR DESCRIPTION
This pull request improves the login error handling in the `login.html` template by displaying more specific error messages based on the type of authentication error encountered. This enhances the user experience by providing clearer feedback during login failures.

Error handling improvements:

* Updated the login error alert to check for `form.non_field_errors` and display custom messages for each error, including a specific message for the `'invalid_login'` error code and defaulting to the error's message for other cases. If no specific errors are present, it falls back to the generic "Username and/or password uncorrect" message. (`g3w-admin/templates/login.html`)
