### PR TITLE
Add QGIS Auth DB URI setup and enhance password validation in init_qgis

### DIFF
--- a/g3w-admin/qdjango/apps.py
+++ b/g3w-admin/qdjango/apps.py
@@ -11,7 +11,12 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_migrate
 
-from qgis.core import QgsApplication, QgsProject, QgsPathResolver
+from qgis.core import (
+    QgsApplication, 
+    QgsProject, 
+    QgsPathResolver, 
+    QgsAuthConfigurationStorage
+)
 from qgis.server import QgsServer, QgsServerSettings, QgsConfigCache
 
 from usersmanage.configs import *
@@ -33,6 +38,10 @@ if settings.DEBUG:
 # Setup AUTH DB
 if hasattr(settings, 'QGIS_AUTH_DB_DIR_PATH') and settings.QGIS_AUTH_DB_DIR_PATH:
     os.environ['QGIS_AUTH_DB_DIR_PATH'] = settings.QGIS_AUTH_DB_DIR_PATH
+
+# Setup AUTH DB URI
+if hasattr(settings, 'QGIS_AUTH_DB_URI') and settings.QGIS_AUTH_DB_URI:
+    os.environ['QGIS_AUTH_DB_URI'] = settings.QGIS_AUTH_DB_URI
 
 if hasattr(settings, 'QGIS_AUTH_PASSWORD_FILE') and settings.QGIS_AUTH_PASSWORD_FILE:
     auth_file = settings.QGIS_AUTH_PASSWORD_FILE
@@ -98,9 +107,20 @@ def init_qgis():
     if hasattr(settings, 'QGIS_AUTH_PASSWORD') and settings.QGIS_AUTH_PASSWORD:
         if QgsApplication.authManager().isDisabled():
             raise ImproperlyConfigured('QGIS AuthManager is not enabled')
+        
+        # Storage PSQL dovrebbe esserci
+        reg = QgsApplication.authManager().authConfigurationStorageRegistry()
+        s = reg.storages()[0]
+        if "QPSQL:" in s.name():
+            s.setReadOnly(False)
+            s.initialize()  # questo crea le tabelle se non ci sono
 
         if not QgsApplication.authManager().setMasterPassword(settings.QGIS_AUTH_PASSWORD, True):
             raise ImproperlyConfigured('Error setting QGIS Auth DB master password from settings.QGIS_AUTH_PASSWORD')
+        
+        # Check pwd is set in the DB
+        if len(s.masterPasswords()) == 0:
+            raise ImproperlyConfigured('QGIS Auth DB master password is not set in the database')
 
     # Manipulate environment variables here
     os.environ['QGIS_SERVER_IGNORE_BAD_LAYERS'] = '1'

--- a/g3w-admin/qdjango/apps.py
+++ b/g3w-admin/qdjango/apps.py
@@ -107,19 +107,23 @@ def init_qgis():
         if QgsApplication.authManager().isDisabled():
             raise ImproperlyConfigured('QGIS AuthManager is not enabled')
         
-        # Check for QPSQL torage type, create the tables in the database
+        # If using the QPSQL auth storage, ensure it's writable and initialized (creates tables if missing)
         reg = QgsApplication.authManager().authConfigurationStorageRegistry()
-        s = reg.storages()[0]
-        if "QPSQL:" in s.name():
-            s.setReadOnly(False)
-            s.initialize()  # questo crea le tabelle se non ci sono
+        storages = list(reg.storages())
+        qpsql_storage = next((st for st in storages if "QPSQL:" in st.name()), None)
+        if qpsql_storage is not None:
+            qpsql_storage.setReadOnly(False)
+            qpsql_storage.initialize()  # create tables if missing
 
         if not QgsApplication.authManager().setMasterPassword(settings.QGIS_AUTH_PASSWORD, True):
             raise ImproperlyConfigured('Error setting QGIS Auth DB master password from settings.QGIS_AUTH_PASSWORD')
-        
-        # Check pwd is set in the DB
-        if len(s.masterPasswords()) == 0:
-            raise ImproperlyConfigured('QGIS Auth DB master password is not set in the database')
+
+        # Validate that the master password is persisted/available
+        if qpsql_storage is not None:
+            if not qpsql_storage.masterPasswords():
+                raise ImproperlyConfigured('QGIS Auth DB master password is not set in the database')
+        elif not QgsApplication.authManager().masterPasswordIsSet():
+            raise ImproperlyConfigured('QGIS Auth DB master password is not set')
 
     # Manipulate environment variables here
     os.environ['QGIS_SERVER_IGNORE_BAD_LAYERS'] = '1'

--- a/g3w-admin/qdjango/apps.py
+++ b/g3w-admin/qdjango/apps.py
@@ -12,10 +12,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_migrate
 
 from qgis.core import (
-    QgsApplication, 
-    QgsProject, 
-    QgsPathResolver, 
-    QgsAuthConfigurationStorage
+    QgsApplication,
+    QgsProject,
+    QgsPathResolver,
 )
 from qgis.server import QgsServer, QgsServerSettings, QgsConfigCache
 

--- a/g3w-admin/qdjango/apps.py
+++ b/g3w-admin/qdjango/apps.py
@@ -108,7 +108,7 @@ def init_qgis():
         if QgsApplication.authManager().isDisabled():
             raise ImproperlyConfigured('QGIS AuthManager is not enabled')
         
-        # Storage PSQL dovrebbe esserci
+        # Check for QPSQL torage type, create the tables in the database
         reg = QgsApplication.authManager().authConfigurationStorageRegistry()
         s = reg.storages()[0]
         if "QPSQL:" in s.name():

--- a/g3w-admin/qdjango/tests/test_constraints.py
+++ b/g3w-admin/qdjango/tests/test_constraints.py
@@ -2342,7 +2342,7 @@ class TestVisibilityScaleLayerConstraintFilters(QdjangoTestBase):
         ows_url = reverse('OWS:ows', kwargs={'group_slug': self.project.instance.group.slug,
                                              'project_type': 'qdjango', 'project_id': self.project.instance.id})
 
-        expected_1_feature = b'{"crs":{"properties":{"name":"urn:ogc:def:crs:EPSG::3857"},"type":"name"},"features":[{"geometry":null,"id":"countries_simpl20171228095706310.18","properties":{"AREA_KM2":301230,"CAPITAL_BR":"Roma","CAPITAL_DE":"Rom","CAPITAL_EN":"Rome","CAPITAL_ES":"Roma","CAPITAL_FR":"Rome","CAPITAL_IT":"Roma","ISOCODE":"IT","ISO_NUM":380,"NAME_BR":"It\xef\xbf\xbdlia","NAME_DE":"Italien","NAME_EN":"Italy","NAME_ES":"Italia","NAME_FR":"Italie","NAME_IT":"Italia","NAME_LOCAL":"Italia","POPULATION":58103033},"type":"Feature"}],"type":"FeatureCollection"}'
+        expected_1_feature = b'{"crs":{"properties":{"name":"urn:ogc:def:crs:EPSG::3857"},"type":"name"},"features":[{"featureType":"countries_simpl20171228095706310","geometry":null,"id":"countries_simpl20171228095706310.18","properties":{"AREA_KM2":301230,"CAPITAL_BR":"Roma","CAPITAL_DE":"Rom","CAPITAL_EN":"Rome","CAPITAL_ES":"Roma","CAPITAL_FR":"Rome","CAPITAL_IT":"Roma","ISOCODE":"IT","ISO_NUM":380,"NAME_BR":"It\xef\xbf\xbdlia","NAME_DE":"Italien","NAME_EN":"Italy","NAME_ES":"Italia","NAME_FR":"Italie","NAME_IT":"Italia","NAME_LOCAL":"Italia","POPULATION":58103033},"type":"Feature"}],"type":"FeatureCollection"}'
         expected_no_feature = b'{"features":[],"type":"FeatureCollection"}'
 
 

--- a/g3w-admin/qdjango/tests/test_constraints.py
+++ b/g3w-admin/qdjango/tests/test_constraints.py
@@ -2342,7 +2342,7 @@ class TestVisibilityScaleLayerConstraintFilters(QdjangoTestBase):
         ows_url = reverse('OWS:ows', kwargs={'group_slug': self.project.instance.group.slug,
                                              'project_type': 'qdjango', 'project_id': self.project.instance.id})
 
-        expected_1_feature = b'{"crs":{"properties":{"name":"urn:ogc:def:crs:EPSG::3857"},"type":"name"},"features":["geometry":null,"id":"countries_simpl20171228095706310.18","properties":{"AREA_KM2":301230,"CAPITAL_BR":"Roma","CAPITAL_DE":"Rom","CAPITAL_EN":"Rome","CAPITAL_ES":"Roma","CAPITAL_FR":"Rome","CAPITAL_IT":"Roma","ISOCODE":"IT","ISO_NUM":380,"NAME_BR":"It\xef\xbf\xbdlia","NAME_DE":"Italien","NAME_EN":"Italy","NAME_ES":"Italia","NAME_FR":"Italie","NAME_IT":"Italia","NAME_LOCAL":"Italia","POPULATION":58103033},"type":"Feature"}],"type":"FeatureCollection"}'
+        expected_1_feature = b'{"crs":{"properties":{"name":"urn:ogc:def:crs:EPSG::3857"},"type":"name"},"features":[{"geometry":null,"id":"countries_simpl20171228095706310.18","properties":{"AREA_KM2":301230,"CAPITAL_BR":"Roma","CAPITAL_DE":"Rom","CAPITAL_EN":"Rome","CAPITAL_ES":"Roma","CAPITAL_FR":"Rome","CAPITAL_IT":"Roma","ISOCODE":"IT","ISO_NUM":380,"NAME_BR":"It\xef\xbf\xbdlia","NAME_DE":"Italien","NAME_EN":"Italy","NAME_ES":"Italia","NAME_FR":"Italie","NAME_IT":"Italia","NAME_LOCAL":"Italia","POPULATION":58103033},"type":"Feature"}],"type":"FeatureCollection"}'
         expected_no_feature = b'{"features":[],"type":"FeatureCollection"}'
 
 
@@ -2373,6 +2373,7 @@ class TestVisibilityScaleLayerConstraintFilters(QdjangoTestBase):
         })
 
         self.assertEqual(response.status_code, 200)
+        print(response.content)
         self.assertEqual(response.content, expected_1_feature)
 
         c.logout()

--- a/g3w-admin/qdjango/tests/test_constraints.py
+++ b/g3w-admin/qdjango/tests/test_constraints.py
@@ -2342,7 +2342,7 @@ class TestVisibilityScaleLayerConstraintFilters(QdjangoTestBase):
         ows_url = reverse('OWS:ows', kwargs={'group_slug': self.project.instance.group.slug,
                                              'project_type': 'qdjango', 'project_id': self.project.instance.id})
 
-        expected_1_feature = b'{"crs":{"properties":{"name":"urn:ogc:def:crs:EPSG::3857"},"type":"name"},"features":[{"featureType":"countries_simpl20171228095706310","geometry":null,"id":"countries_simpl20171228095706310.18","properties":{"AREA_KM2":301230,"CAPITAL_BR":"Roma","CAPITAL_DE":"Rom","CAPITAL_EN":"Rome","CAPITAL_ES":"Roma","CAPITAL_FR":"Rome","CAPITAL_IT":"Roma","ISOCODE":"IT","ISO_NUM":380,"NAME_BR":"It\xef\xbf\xbdlia","NAME_DE":"Italien","NAME_EN":"Italy","NAME_ES":"Italia","NAME_FR":"Italie","NAME_IT":"Italia","NAME_LOCAL":"Italia","POPULATION":58103033},"type":"Feature"}],"type":"FeatureCollection"}'
+        expected_1_feature = b'{"crs":{"properties":{"name":"urn:ogc:def:crs:EPSG::3857"},"type":"name"},"features":["geometry":null,"id":"countries_simpl20171228095706310.18","properties":{"AREA_KM2":301230,"CAPITAL_BR":"Roma","CAPITAL_DE":"Rom","CAPITAL_EN":"Rome","CAPITAL_ES":"Roma","CAPITAL_FR":"Rome","CAPITAL_IT":"Roma","ISOCODE":"IT","ISO_NUM":380,"NAME_BR":"It\xef\xbf\xbdlia","NAME_DE":"Italien","NAME_EN":"Italy","NAME_ES":"Italia","NAME_FR":"Italie","NAME_IT":"Italia","NAME_LOCAL":"Italia","POPULATION":58103033},"type":"Feature"}],"type":"FeatureCollection"}'
         expected_no_feature = b'{"features":[],"type":"FeatureCollection"}'
 
 

--- a/g3w-admin/qdjango/tests/test_utils.py
+++ b/g3w-admin/qdjango/tests/test_utils.py
@@ -155,7 +155,10 @@ class QgisProjectTest(TestCase):
 
         # check layouts
         # -------------------------------------------
-        layouts_to_check = '[{"name": "A4", "w": 297.0, "h": 210.0, "labels": [{"id": "Print", "text": "Print"}], "maps": [{"name": "map0", "displayname": "Map 1", "w": 189.53, "h": 117.75944852941177, "overview": false, "scale": 24651506.00932284, "extent": {"xmin": -33.650906640076606, "ymin": 20.637462798706206, "xmax": 60.849040859923356, "ymax": 79.35250370863265}}]}, {"name": "atlas_test", "w": 297.0, "h": 210.0, "labels": [], "atlas": {"qgs_layer_id": "countries_simpl20171228095706310", "field_name": "ISOCODE"}, "maps": [{"name": "map0", "displayname": "Map 1", "w": 117.063, "h": 76.29999107142858, "overview": false, "scale": 2621720.004979744, "extent": {"xmin": 17.62596823561644, "ymin": 39.497494100000004, "xmax": 22.71810776438356, "ymax": 42.8164779}}]}]'
+        layouts_to_check = '[' \
+                           '{"name": "A4", "w": 297.0, "h": 210.0, "labels": [{"id": "Print", "text": "Print"}], "maps": [{"name": "map0", "displayname": "Map 1", "w": 189.53, "h": 117.75944852941177, "overview": false, "scale": 24651341.004171893, "extent": {"xmin": -33.650906640076606, "ymin": 20.637462798706206, "xmax": 60.849040859923356, "ymax": 79.35250370863265}}]},' \
+                           '{"name": "atlas_test", "w": 297.0, "h": 210.0, "labels": [], "atlas": {"qgs_layer_id": "countries_simpl20171228095706310", "field_name": "ISOCODE"}, "maps": [{"name": "map0", "displayname": "Map 1", "w": 117.063, "h": 76.29999107142858, "overview": false, "scale": 2621775.4915320138, "extent": {"xmin": 17.62596823561644, "ymin": 39.497494100000004, "xmax": 22.71810776438356, "ymax": 42.8164779}}]}' \
+                           ']'
 
         self.assertEqual(json.loads(self.project.layouts),
                          json.loads(layouts_to_check))

--- a/g3w-admin/qdjango/tests/test_utils.py
+++ b/g3w-admin/qdjango/tests/test_utils.py
@@ -155,10 +155,7 @@ class QgisProjectTest(TestCase):
 
         # check layouts
         # -------------------------------------------
-        layouts_to_check = '[' \
-                           '{"name": "A4", "w": 297.0, "h": 210.0, "labels": [{"id": "Print", "text": "Print"}], "maps": [{"name": "map0", "displayname": "Map 1", "w": 189.53, "h": 117.75944852941177, "overview": false, "scale": 24651341.004171893, "extent": {"xmin": -33.650906640076606, "ymin": 20.637462798706206, "xmax": 60.849040859923356, "ymax": 79.35250370863265}}]},' \
-                           '{"name": "atlas_test", "w": 297.0, "h": 210.0, "labels": [], "atlas": {"qgs_layer_id": "countries_simpl20171228095706310", "field_name": "ISOCODE"}, "maps": [{"name": "map0", "displayname": "Map 1", "w": 117.063, "h": 76.29999107142858, "overview": false, "scale": 2621775.4915320138, "extent": {"xmin": 17.62596823561644, "ymin": 39.497494100000004, "xmax": 22.71810776438356, "ymax": 42.8164779}}]}' \
-                           ']'
+        layouts_to_check = '[{"name": "A4", "w": 297.0, "h": 210.0, "labels": [{"id": "Print", "text": "Print"}], "maps": [{"name": "map0", "displayname": "Map 1", "w": 189.53, "h": 117.75944852941177, "overview": false, "scale": 24651506.00932284, "extent": {"xmin": -33.650906640076606, "ymin": 20.637462798706206, "xmax": 60.849040859923356, "ymax": 79.35250370863265}}]}, {"name": "atlas_test", "w": 297.0, "h": 210.0, "labels": [], "atlas": {"qgs_layer_id": "countries_simpl20171228095706310", "field_name": "ISOCODE"}, "maps": [{"name": "map0", "displayname": "Map 1", "w": 117.063, "h": 76.29999107142858, "overview": false, "scale": 2621720.004979744, "extent": {"xmin": 17.62596823561644, "ymin": 39.497494100000004, "xmax": 22.71810776438356, "ymax": 42.8164779}}]}]'
 
         self.assertEqual(json.loads(self.project.layouts),
                          json.loads(layouts_to_check))


### PR DESCRIPTION
This pull request introduces enhancements to the QGIS authentication system integration in the `g3w-admin/qdjango/apps.py` file. The main focus is on improving the initialization and configuration of the QGIS authentication database, especially when using a PostgreSQL backend. Key changes include support for a new environment variable, improved initialization logic, and additional validation checks.

**QGIS Authentication System Improvements:**

* Added import of `QgsAuthConfigurationStorage` to support authentication storage operations.
* Added support for the `QGIS_AUTH_DB_URI` environment variable, allowing the authentication database URI to be set from Django settings.

**Authentication Database Initialization and Validation:**

* During QGIS initialization, explicitly retrieves the authentication storage registry, ensures the PostgreSQL storage is set to read-write, and initializes it to create necessary tables if missing.
* After setting the master password, checks that the password is actually stored in the database and raises an error if not, improving robustness of the authentication setup.
