### PR TITLE
Show help message tool if startEditing api method is call by external plugin

### DIFF
--- a/g3w-admin/editing/static/editing/js/components/toolbox.js
+++ b/g3w-admin/editing/static/editing/js/components/toolbox.js
@@ -529,11 +529,17 @@ export default ({
 
   watch: {
 
-    async 'state.activetool'(tool) {
-      await this.$nextTick();
-      this.helpmessage = tool?.messages?.help || tool?.name;
+    /**
+     * @since 4.0.0
+     * check immediately if the active tool has changed to update the help message
+     */
+    'state.activetool': {
+      immediate: true,
+      async handler(tool) {
+        await this.$nextTick();
+        this.helpmessage = tool?.messages?.help || tool?.name;
+      }
     },
-    
     'state.toolsoftool'(nts = [], ots = []) {
       //no tools
       if (nts.length === ots.length) { return; }

--- a/g3w-admin/editing/static/editing/js/components/toolbox.js
+++ b/g3w-admin/editing/static/editing/js/components/toolbox.js
@@ -232,7 +232,6 @@ export default ({
   data() {
     return {
       active:      false,
-      helpmessage: null,
       //@since 3.8.0
       toggled:     {
         relation: false, //click on relation icon
@@ -243,6 +242,14 @@ export default ({
   },
 
   computed: {
+
+    /**
+     * @returns @since 4.0.0
+     * 
+     */
+    helpmessage() {
+      return this.state.activetool?.messages?.help ?? this.state.activetool?.name;
+    },
 
     /**
      * @since g3w-client-plugin-editing@v3.7.0
@@ -529,17 +536,6 @@ export default ({
 
   watch: {
 
-    /**
-     * @since 4.0.0
-     * check immediately if the active tool has changed to update the help message
-     */
-    'state.activetool': {
-      immediate: true,
-      async handler(tool) {
-        await this.$nextTick();
-        this.helpmessage = tool?.messages?.help || tool?.name;
-      }
-    },
     'state.toolsoftool'(nts = [], ots = []) {
       //no tools
       if (nts.length === ots.length) { return; }

--- a/g3w-admin/editing/static/editing/js/components/toolbox.js
+++ b/g3w-admin/editing/static/editing/js/components/toolbox.js
@@ -248,7 +248,7 @@ export default ({
      * 
      */
     helpmessage() {
-      return this.state.activetool?.messages?.help ?? this.state.activetool?.name;
+      return this.state.activetool?.helpMessage ?? this.state.activetool?.name;
     },
 
     /**

--- a/g3w-admin/editing/static/editing/js/g3w-step.js
+++ b/g3w-admin/editing/static/editing/js/g3w-step.js
@@ -540,10 +540,3 @@ export class Step extends Emitter {
   }
 
 }
-
-/**
- * @FIXME add description
- */
-Step.MESSAGES = {
-  help: null,
-};

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -2391,12 +2391,7 @@ export class ToolBox extends Emitter {
             tool.visible              = undefined === options.visible              ? true :  options.visible;
             tool.enabled              = undefined === options.enabled              ? false : options.enabled;
             tool.disabledtoolsoftools = undefined === options.disabledtoolsoftools ? [] :    options.disabledtoolsoftools;
-            //@since 4.0.0 set help message of tool operator in case of external plugin
-            // https://github.com/g3w-suite/g3w-admin-simplereporting/blob/bb8727a966970491e08472b1e8f83a1a95bafb54/simplereporting/static/simplereporting/js/service.js#L227
-            // use startEditing api to start editing and set help message of tool operator 
-            if (options?.messages?.help) {
-              tool.getOperator()?.setHelpMessage(options?.messages?.help);
-            }
+            
             if (tool.visible) {
               toolsId.push(id);
             }

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -2469,7 +2469,6 @@ export class ToolBox extends Emitter {
         })
         // set tool messages
         const messages      = (workflow.getHelpMessage() || workflow.getRunningStep()) ? this.state.activetool.messages : null;
-        console.log('messages', messages);
         this.state.toolmessages.help = messages && messages.help || null;
       }
 

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -322,7 +322,6 @@ export class ToolBox extends Emitter {
       toolboxheader    : true,
       startstopediting : true,
       message          : null,
-      toolmessages     : { help: null }, //@TODO Check if is used 
       toolsoftool      : [],
       selected         : false,
       activetool       : null,
@@ -2172,7 +2171,6 @@ export class ToolBox extends Emitter {
    *
    */
   clearToolboxMessages() {
-    this.state.toolmessages.help = null;
     this.clearMessage();
   }
 
@@ -2461,8 +2459,6 @@ export class ToolBox extends Emitter {
           //set empty tools of tools
           this.state.toolsoftool = (ts || []).filter(t => !tool.disabledtoolsoftools.includes(t.type))
         });
-        //In case of runnging step, check if help message is set otherwise return null
-        this.state.toolmessages.help = (workflow.getRunningStep() && tool.helpMessage) ?? null;
         //set as active tool
         this.state.activetool = tool;
       }
@@ -2495,7 +2491,6 @@ export class ToolBox extends Emitter {
       }
       //@since 3.9.1 Changed to set empty array cause reactivity of vue instead of splice(0)
       this.state.toolsoftool       = [];
-      this.state.toolmessages.help = null;
       this.state.activetool        = null;
     } catch(e) {
       console.warn(e);

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -2449,11 +2449,9 @@ export class ToolBox extends Emitter {
   async setActiveTool(tool) {
 
     try {
+      //stop current active tool
       await this.stopActiveTool(tool);
-
-      //set as active tool
-      this.state.activetool = tool;
-
+      //get workflow operator of tool
       const workflow = tool.getOperator();
       //only in case tool has a operator (workflow) start it and set messages
       if (workflow) {
@@ -2464,7 +2462,9 @@ export class ToolBox extends Emitter {
           this.state.toolsoftool = (ts || []).filter(t => !tool.disabledtoolsoftools.includes(t.type))
         });
         //In case of runnging step, check if help message is set otherwise return null
-        this.state.toolmessages.help = (workflow.getRunningStep() && this.state.activetool.messages?.help) ?? null;
+        this.state.toolmessages.help = (workflow.getRunningStep() && tool.messages?.help) ?? null;
+        //set as active tool
+        this.state.activetool = tool;
       }
 
     } catch(e) {

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -376,7 +376,7 @@ export class ToolBox extends Emitter {
           /** ORIGINAL SOURCE: g3w-client-plugin-editing/workflows/editfeatureattributesworkflow.js@v3.7.1 */
           op: new Workflow({
             layer,
-            messages: { help: 'editing.tools.update_feature' },
+            helpMessage: 'editing.tools.update_feature',
             type: 'editfeatureattributes',
             steps: [
               new PickFeatureStep(),
@@ -497,7 +497,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type: 'modifygeometryvertex',
-            messages: { help: 'editing.tools.update_vertex' },
+            helpMessage: 'editing.tools.update_vertex',
             steps: [
               new PickFeatureStep({ layer }),
               new Step({ run: chooseFeature }),
@@ -515,7 +515,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type: 'editmultiattributes',
-            messages: { help: 'editing.tools.update_multi_features' },
+            helpMessage: 'editing.tools.update_multi_features',
             registerEscKeyEvent: true,
             runOnce: true,
             steps: [
@@ -549,7 +549,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type:                'editmultiattributesrelationfeatures',
-            messages: { help: 'editing.tools.update_multi_features_relations_from_parents' },
+            helpMessage: 'editing.tools.update_multi_features_relations_from_parents',
             registerEscKeyEvent: true,
             runOnce:             true,
             steps: [
@@ -798,7 +798,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type: 'movefeature',
-            messages: { help: 'editing.tools.move_feature' },
+            helpMessage: 'editing.tools.move_feature',
             steps: [
               new PickFeatureStep(),
               new Step({ run: chooseFeature }),
@@ -816,7 +816,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type: 'rotatefeature',
-            messages: { help: 'editing.tools.rotate_feature' },
+            helpMessage: 'editing.tools.rotate_feature',
             steps: [
               new PickFeatureStep(),
               new Step({ run: chooseFeature }),
@@ -1047,7 +1047,7 @@ export class ToolBox extends Emitter {
                   }),
                   openFormStep,
                 ],
-                messages: { help: "editing.tools.pastefeaturesfromotherlayers" },
+                helpMessage: "editing.tools.pastefeaturesfromotherlayers",
                 registerEscKeyEvent: true
               });
             })(),
@@ -1204,7 +1204,7 @@ export class ToolBox extends Emitter {
                 }
               }),
             ].filter(Boolean),
-            messages: { help: "editing.tools.copy" },
+            helpMessage: "editing.tools.copy",
             registerEscKeyEvent: true,
           }),
         },
@@ -1219,7 +1219,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type:        'addparttomultigeometries',
-            messages: { help: 'editing.tools.addpart' },
+            helpMessage: 'editing.tools.addpart',
             runOnce:     true,
             steps: [
               new PickFeatureStep({
@@ -1358,7 +1358,7 @@ export class ToolBox extends Emitter {
                 },
               }),
             ],
-            messages: { help: 'editing.tools.deletepart' },
+            helpMessage: 'editing.tools.deletepart',
           }),
         },
         // Split Feature
@@ -1459,7 +1459,7 @@ export class ToolBox extends Emitter {
                 }
               }),
             ],
-            messages: { help: 'editing.tools.split' },
+            helpMessage: 'editing.tools.split',
             registerEscKeyEvent: true,
           }),
         },
@@ -1551,7 +1551,7 @@ export class ToolBox extends Emitter {
                 },
               }),
             ],
-            messages: { help: 'editing.tools.merge' },
+            helpMessage: 'editing.tools.merge',
             registerEscKeyEvent: true
           }),
         },
@@ -1630,7 +1630,7 @@ export class ToolBox extends Emitter {
         enabled:              !!tool.enabled,
         active:               false,
         message:              null,
-        messages:             tool.op.getMessages(),
+        helpMessage:          tool.op.getHelpMessage(),
         visible:              tool.visible instanceof Function ? tool.visible(tool) : (undefined !== tool.visible ? tool.visible: true),
         state:                new Proxy({}, { get: (_, prop) => tool[prop], set:(_, prop, value) => { tool[prop] = value; return true; } }),
         start:                this._startTool.bind(this, tool),
@@ -2387,7 +2387,7 @@ export class ToolBox extends Emitter {
           if (tool) {
             const { active = false } = options;
             // set tool options
-            tool.messages             = options.messages || tool.messages;
+            tool.helpMessage          = options.helpMessage ?? tool.helpMessage;
             tool.visible              = undefined === options.visible              ? true :  options.visible;
             tool.enabled              = undefined === options.enabled              ? false : options.enabled;
             tool.disabledtoolsoftools = undefined === options.disabledtoolsoftools ? [] :    options.disabledtoolsoftools;
@@ -2462,7 +2462,7 @@ export class ToolBox extends Emitter {
           this.state.toolsoftool = (ts || []).filter(t => !tool.disabledtoolsoftools.includes(t.type))
         });
         //In case of runnging step, check if help message is set otherwise return null
-        this.state.toolmessages.help = (workflow.getRunningStep() && tool.messages?.help) ?? null;
+        this.state.toolmessages.help = (workflow.getRunningStep() && tool.helpMessage) ?? null;
         //set as active tool
         this.state.activetool = tool;
       }
@@ -2541,7 +2541,7 @@ export class ToolBox extends Emitter {
       this.state._tools.forEach(tool => {
         tool.visible              = true;
         tool.enabled              = false;
-        tool.messages             = tool.op.getMessages();
+        tool.helpMessage          = tool.op.getHelpMessage();
         tool.disabledtoolsoftools = []; //reset disabled tools eventually set by other
       });
     }

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -1639,7 +1639,7 @@ export class ToolBox extends Emitter {
         getOperator:          () => tool.op,
         setOperator:          op => tool.op = op,
         disableEdit:          !!tool.disableEdit, //@since v4.0.0 disable stop editing
-      })
+      });
     });
 
     Object.assign(this.state, {
@@ -2460,19 +2460,17 @@ export class ToolBox extends Emitter {
       this.state.activetool = tool;
 
       const workflow = tool.getOperator();
-
+      //only in case tool has a operator (workflow) start it and set messages
       if (workflow) {
+        tool.start();
         // filter eventually disable tools of tools
         workflow.on('settoolsoftool', ts => {
           //set empty tools of tools
           this.state.toolsoftool = (ts || []).filter(t => !tool.disabledtoolsoftools.includes(t.type))
-        })
-        // set tool messages
-        const messages      = (workflow.getHelpMessage() || workflow.getRunningStep()) ? this.state.activetool.messages : null;
-        this.state.toolmessages.help = messages && messages.help || null;
+        });
+        //In case of runnging step, check if help message is set otherwise return null
+        this.state.toolmessages.help = (workflow.getRunningStep() && this.state.activetool.messages?.help) ?? null;
       }
-
-      tool.start();
 
     } catch(e) {
       console.warn(e);

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -322,7 +322,7 @@ export class ToolBox extends Emitter {
       toolboxheader    : true,
       startstopediting : true,
       message          : null,
-      toolmessages     : { help: null },
+      toolmessages     : { help: null }, //@TODO Check if is used 
       toolsoftool      : [],
       selected         : false,
       activetool       : null,

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -376,7 +376,7 @@ export class ToolBox extends Emitter {
           /** ORIGINAL SOURCE: g3w-client-plugin-editing/workflows/editfeatureattributesworkflow.js@v3.7.1 */
           op: new Workflow({
             layer,
-            helpMessage: 'editing.tools.update_feature',
+            messages: { help: 'editing.tools.update_feature' },
             type: 'editfeatureattributes',
             steps: [
               new PickFeatureStep(),
@@ -497,7 +497,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type: 'modifygeometryvertex',
-            helpMessage: 'editing.tools.update_vertex',
+            messages: { help: 'editing.tools.update_vertex' },
             steps: [
               new PickFeatureStep({ layer }),
               new Step({ run: chooseFeature }),
@@ -515,7 +515,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type: 'editmultiattributes',
-            helpMessage: 'editing.tools.update_multi_features',
+            messages: { help: 'editing.tools.update_multi_features' },
             registerEscKeyEvent: true,
             runOnce: true,
             steps: [
@@ -549,7 +549,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type:                'editmultiattributesrelationfeatures',
-            helpMessage:         'editing.tools.update_multi_features_relations_from_parents',
+            messages: { help: 'editing.tools.update_multi_features_relations_from_parents' },
             registerEscKeyEvent: true,
             runOnce:             true,
             steps: [
@@ -798,7 +798,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type: 'movefeature',
-            helpMessage: 'editing.tools.move_feature',
+            messages: { help: 'editing.tools.move_feature' },
             steps: [
               new PickFeatureStep(),
               new Step({ run: chooseFeature }),
@@ -816,7 +816,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type: 'rotatefeature',
-            helpMessage: 'editing.tools.rotate_feature',
+            messages: { help: 'editing.tools.rotate_feature' },
             steps: [
               new PickFeatureStep(),
               new Step({ run: chooseFeature }),
@@ -1047,7 +1047,7 @@ export class ToolBox extends Emitter {
                   }),
                   openFormStep,
                 ],
-                helpMessage: "editing.tools.pastefeaturesfromotherlayers",
+                messages: { help: "editing.tools.pastefeaturesfromotherlayers" },
                 registerEscKeyEvent: true
               });
             })(),
@@ -1204,7 +1204,7 @@ export class ToolBox extends Emitter {
                 }
               }),
             ].filter(Boolean),
-            helpMessage: "editing.tools.copy",
+            messages: { help: "editing.tools.copy" },
             registerEscKeyEvent: true,
           }),
         },
@@ -1219,7 +1219,7 @@ export class ToolBox extends Emitter {
           op: new Workflow({
             layer,
             type:        'addparttomultigeometries',
-            helpMessage: 'editing.tools.addpart',
+            messages: { help: 'editing.tools.addpart' },
             runOnce:     true,
             steps: [
               new PickFeatureStep({
@@ -1358,7 +1358,7 @@ export class ToolBox extends Emitter {
                 },
               }),
             ],
-            helpMessage: 'editing.tools.deletepart',
+            messages: { help: 'editing.tools.deletepart' },
           }),
         },
         // Split Feature
@@ -1459,7 +1459,7 @@ export class ToolBox extends Emitter {
                 }
               }),
             ],
-            helpMessage: 'editing.tools.split',
+            messages: { help: 'editing.tools.split' },
             registerEscKeyEvent: true,
           }),
         },
@@ -1551,7 +1551,7 @@ export class ToolBox extends Emitter {
                 },
               }),
             ],
-            helpMessage: 'editing.tools.merge',
+            messages: { help: 'editing.tools.merge' },
             registerEscKeyEvent: true
           }),
         },

--- a/g3w-admin/editing/static/editing/js/g3w-toolbox.js
+++ b/g3w-admin/editing/static/editing/js/g3w-toolbox.js
@@ -2383,7 +2383,7 @@ export class ToolBox extends Emitter {
       enableTools
         .forEach(({ id, options = {} }) => {
           //check if id of tool passed as argument is right
-          const tool =this.getToolById(id);
+          const tool = this.getToolById(id);
           if (tool) {
             const { active = false } = options;
             // set tool options
@@ -2391,6 +2391,12 @@ export class ToolBox extends Emitter {
             tool.visible              = undefined === options.visible              ? true :  options.visible;
             tool.enabled              = undefined === options.enabled              ? false : options.enabled;
             tool.disabledtoolsoftools = undefined === options.disabledtoolsoftools ? [] :    options.disabledtoolsoftools;
+            //@since 4.0.0 set help message of tool operator in case of external plugin
+            // https://github.com/g3w-suite/g3w-admin-simplereporting/blob/bb8727a966970491e08472b1e8f83a1a95bafb54/simplereporting/static/simplereporting/js/service.js#L227
+            // use startEditing api to start editing and set help message of tool operator 
+            if (options?.messages?.help) {
+              tool.getOperator()?.setHelpMessage(options?.messages?.help);
+            }
             if (tool.visible) {
               toolsId.push(id);
             }
@@ -2463,6 +2469,7 @@ export class ToolBox extends Emitter {
         })
         // set tool messages
         const messages      = (workflow.getHelpMessage() || workflow.getRunningStep()) ? this.state.activetool.messages : null;
+        console.log('messages', messages);
         this.state.toolmessages.help = messages && messages.help || null;
       }
 

--- a/g3w-admin/editing/static/editing/js/g3w-workflow.js
+++ b/g3w-admin/editing/static/editing/js/g3w-workflow.js
@@ -97,11 +97,9 @@ export class Workflow extends Emitter {
     this.runOnce = options?.runOnce || false;
 
     /**
-     * Set messages for workflow (ex. help message)
+     * Workflow help message key
      */
-    this._messages = options.messages ?? {
-      help: options.helpMessage ?? null,
-    };
+    this._helpMessage = options?.helpMessage ?? null;
 
     /**
      * Store user messages steps to show when workflow
@@ -259,24 +257,10 @@ export class Workflow extends Emitter {
   }
 
   /**
-   * @param messages
-   */
-  setMessages(messages) {
-    Object.assign(this._messages, messages);
-  }
-
-  /**
-   * @FIXME add description
-   */
-  getMessages() {
-    return this._messages;
-  }
-
-  /**
    * @FIXME add description
    */
   clearMessages() {
-    this._messages.help = null;
+    this.setHelpMessage(null);
     if (Object.keys(this._userMessageSteps).length > 0) {
       this.clearUserMessagesSteps();
     }
@@ -324,7 +308,7 @@ export class Workflow extends Emitter {
   async runStep(step, inputs) {
     try {
       //set step message
-      this.setMessages({ help: step.state.help });
+      this.setHelpMessage(step.state.help);
 
       //@since 3.9.1
       this.emit('settoolsoftool', (step.tools || []));
@@ -384,7 +368,7 @@ export class Workflow extends Emitter {
           type:      'tool',
           closable:  false,
           iconClass: 'tasks',
-          subtitle:  this._messages?.help && `plugins.${this._messages?.help}`,
+          subtitle:  this.getHelpMessage() && `plugins.${this.getHelpMessage()}`,
           hooks: {
             body: {
               template: /* html */`
@@ -572,7 +556,7 @@ export class Workflow extends Emitter {
    * @since g3w-client-editing@v3.8.0
    */
   setHelpMessage(message) {
-    this._messages.help  = message ;
+    this._helpMessage = message;
   }
 
   /**
@@ -581,7 +565,7 @@ export class Workflow extends Emitter {
    * @since g3w-client-editing@v3.8.0
    */
   getHelpMessage() {
-    return this._messages.help;
+    return this._helpMessage;
   }
 
   /**

--- a/g3w-admin/editing/static/editing/js/g3w-workflow.js
+++ b/g3w-admin/editing/static/editing/js/g3w-workflow.js
@@ -97,9 +97,11 @@ export class Workflow extends Emitter {
     this.runOnce = options?.runOnce || false;
 
     /**
-     * @FIXME add description
+     * Set messages for workflow (ex. help message)
      */
-    this._messages = Step.MESSAGES;
+    this._messages = options.messages ?? {
+      help: options.helpMessage ?? null,
+    };
 
     /**
      * Store user messages steps to show when workflow
@@ -116,14 +118,7 @@ export class Workflow extends Emitter {
      * 
      * @since 3.9.0
      */
-    this.backbuttonlabel = options?.backbuttonlabel || null;
-
-    /**
-     * ORIGINAL SOURCE: g3w-client-plugin-editing/workflows/editingworkflow.js@v3.7.1
-     * 
-     * @since g3w-client-editing@v3.8.0
-     */
-    this.helpMessage  = options.helpMessage ? { help: options.helpMessage } : null;
+    this.backbuttonlabel = options?.backbuttonlabel || null; 
 
     /**
      * ORIGINAL SOURCE: g3w-client-plugin-editing/workflows/editingworkflow.js@v3.7.1
@@ -389,7 +384,7 @@ export class Workflow extends Emitter {
           type:      'tool',
           closable:  false,
           iconClass: 'tasks',
-          subtitle:  this.helpMessage?.help && `plugins.${this.helpMessage?.help}`,
+          subtitle:  this._messages?.help && `plugins.${this._messages?.help}`,
           hooks: {
             body: {
               template: /* html */`
@@ -577,7 +572,7 @@ export class Workflow extends Emitter {
    * @since g3w-client-editing@v3.8.0
    */
   setHelpMessage(message) {
-    this.helpMessage = { help: message };
+    this._messages.help  = message ;
   }
 
   /**
@@ -586,7 +581,7 @@ export class Workflow extends Emitter {
    * @since g3w-client-editing@v3.8.0
    */
   getHelpMessage() {
-    return this.helpMessage;
+    return this._messages.help;
   }
 
   /**


### PR DESCRIPTION
This pull request improves how help messages are managed and displayed for tools in the editing toolbox, with a focus on supporting external plugins and providing immediate updates when the active tool changes.

**Help message management improvements:**

* The watcher for `state.activetool` in `toolbox.js` now uses an immediate handler to ensure the help message is updated as soon as the active tool changes, improving user feedback.
* When registering a tool, if a help message is provided in the options (e.g., by an external plugin), it is now set directly on the tool's operator using `setHelpMessage`, ensuring consistent help message display for tools integrated via plugins.

**Debugging and visibility:**

* Added a console log to output tool messages during workflow updates, aiding in debugging and verifying help message assignment.

Example simple reporting plugin https://github.com/g3w-suite/g3w-admin-simplereporting

### Before

<img width="424" height="278" alt="Screenshot_20260803_174659" src="https://github.com/user-attachments/assets/9d380f72-d7e6-4b89-8718-8fc959b10dfa" />


### After

<img width="424" height="386" alt="Screenshot_20260803_174631" src="https://github.com/user-attachments/assets/74ca59af-6577-4c47-95c4-b668e6f3702d" />
