### PR TITLE
Fix creation relation with  fields not updated

### DIFF
--- a/g3w-admin/editing/static/editing/js/actions/open-form.js
+++ b/g3w-admin/editing/static/editing/js/actions/open-form.js
@@ -368,7 +368,20 @@ export class OpenFormStep extends Step {
                 GUI.setLoadingContent(true);
                 GUI.disableContent(true);
   
-                await Workflow.Stack.current.getContext().service.saveDefaultExpressionFieldsNotDependencies();
+                const service    = Workflow.Stack.current.getContext().service;
+                const hasUpdates = !!service?.state?.fields?.some(f => f.update);
+                const isNew      = !!this._originalFeatures?.some(f => f.isNew?.());
+
+                // Avoid creating an "update" session change when nothing changed on an existing non-relation feature.
+                if (!this._isContentChild && !isNew && !hasUpdates) {
+                  GUI.setModal(false);
+                  GUI.setLoadingContent(false);
+                  GUI.disableContent(false);
+                  resolve(inputs);
+                  return;
+                }
+
+                await service.saveDefaultExpressionFieldsNotDependencies();
 
                 this._features.forEach(f => {
                   _setFieldsWithValues(inputs.layer, f, fields);

--- a/g3w-admin/editing/static/editing/js/actions/open-form.js
+++ b/g3w-admin/editing/static/editing/js/actions/open-form.js
@@ -373,7 +373,7 @@ export class OpenFormStep extends Step {
                 const isNew      = !!this._originalFeatures?.some(f => f.isNew?.());
 
                 // Avoid creating an "update" session change when nothing changed on an existing non-relation feature.
-                if (!this._isContentChild && !isNew && !hasUpdates) {
+                if (!isNew && !hasUpdates) {
                   GUI.setModal(false);
                   GUI.setLoadingContent(false);
                   GUI.disableContent(false);

--- a/g3w-admin/editing/static/editing/js/actions/open-form.js
+++ b/g3w-admin/editing/static/editing/js/actions/open-form.js
@@ -362,26 +362,23 @@ export class OpenFormStep extends Step {
                   return;
                 }
 
-                const newFeatures = [];
-
-                // @since 3.5.15
-                GUI.setLoadingContent(true);
-                GUI.disableContent(true);
-  
                 const service    = Workflow.Stack.current.getContext().service;
                 //Check if there are updates on the form fields or if the feature is new
                 const hasUpdates = !!service?.state?.fields?.some(f => f.update);
                 //Check if there are new features in the form (i.e., features that are not yet saved to the server)
                 const isNew      = !!this._originalFeatures?.some(f => f.isNew?.());
+                const newFeatures = [];
 
                 // Avoid creating an "update" session change when nothing changed on an existing non-relation feature.
                 if (!isNew && !hasUpdates) {
-                  GUI.setModal(false);
-                  GUI.setLoadingContent(false);
-                  GUI.disableContent(false);
+    
                   resolve(inputs);
                   return;
                 }
+
+                // @since 3.5.15
+                GUI.setLoadingContent(true);
+                GUI.disableContent(true);
 
                 await service.saveDefaultExpressionFieldsNotDependencies();
 
@@ -408,8 +405,6 @@ export class OpenFormStep extends Step {
                   fields,
                   task:     this,
                 });
-
-                GUI.setModal(false);
 
                 GUI.getPlugin('editing').emit('savedfeature', newFeatures);                 // called after saved
                 GUI.getPlugin('editing').emit(`savedfeature_${this.layerId}`, newFeatures); // called after saved using layerId

--- a/g3w-admin/editing/static/editing/js/actions/open-form.js
+++ b/g3w-admin/editing/static/editing/js/actions/open-form.js
@@ -369,7 +369,9 @@ export class OpenFormStep extends Step {
                 GUI.disableContent(true);
   
                 const service    = Workflow.Stack.current.getContext().service;
+                //Check if there are updates on the form fields or if the feature is new
                 const hasUpdates = !!service?.state?.fields?.some(f => f.update);
+                //Check if there are new features in the form (i.e., features that are not yet saved to the server)
                 const isNew      = !!this._originalFeatures?.some(f => f.isNew?.());
 
                 // Avoid creating an "update" session change when nothing changed on an existing non-relation feature.

--- a/g3w-admin/editing/static/editing/js/actions/open-form.js
+++ b/g3w-admin/editing/static/editing/js/actions/open-form.js
@@ -355,13 +355,6 @@ export class OpenFormStep extends Step {
               class: "btn-success",
               // save features
               cbk: async (fields = []) => {
-                fields = this._multi ? fields.filter(f => null !== f.value) : fields;
-                // skip when no fields
-                if (0 === fields.length) {
-                  resolve(inputs);
-                  return;
-                }
-
                 const service    = Workflow.Stack.current.getContext().service;
                 //Check if there are updates on the form fields or if the feature is new
                 const hasUpdates = !!service?.state?.fields?.some(f => f.update);
@@ -369,9 +362,10 @@ export class OpenFormStep extends Step {
                 const isNew      = !!this._originalFeatures?.some(f => f.isNew?.());
                 const newFeatures = [];
 
-                // Avoid creating an "update" session change when nothing changed on an existing non-relation feature.
-                if (!isNew && !hasUpdates) {
-    
+                fields = this._multi ? fields.filter(f => null !== f.value) : fields;
+                
+                // skip when no fields or Avoid creating an "update" session change when nothing changed on an existing non-relation feature.
+                if (0 === fields.length || (!isNew && !hasUpdates)) {
                   resolve(inputs);
                   return;
                 }

--- a/g3w-admin/editing/static/editing/js/actions/open-form.js
+++ b/g3w-admin/editing/static/editing/js/actions/open-form.js
@@ -367,47 +367,43 @@ export class OpenFormStep extends Step {
                 // @since 3.5.15
                 GUI.setLoadingContent(true);
                 GUI.disableContent(true);
+  
+                await Workflow.Stack.current.getContext().service.saveDefaultExpressionFieldsNotDependencies();
 
-                // chek if some changes are present before save otherwise check in relation eventually
-                if (Workflow.Stack.current.getContext().service.state.fields.find(f => f.update)) {
-                  
-                  await Workflow.Stack.current.getContext().service.saveDefaultExpressionFieldsNotDependencies();
+                this._features.forEach(f => {
+                  _setFieldsWithValues(inputs.layer, f, fields);
+                  newFeatures.push(f.clone());
+                });
 
-                  this._features.forEach(f => {
-                    _setFieldsWithValues(inputs.layer, f, fields);
-                    newFeatures.push(f.clone());
-                  });
-
-                  if (this._isContentChild) {
-                    inputs.relationFeatures = {
-                      newFeatures,
-                      originalFeatures: this._originalFeatures
-                    };
-                  }
-
-                  await GUI.getPlugin('editing').emit('saveform', { newFeatures, originalFeatures: this._originalFeatures });
-
-                  newFeatures.forEach((f, i) => context.session.pushUpdate(this.layerId, f, this._originalFeatures[i]));
-
-                  // check and handle if layer has relation 1:1
-                  await _handleRelation1_1LayerFields({
-                    layerId:  this.layerId,
-                    features: newFeatures,
-                    fields,
-                    task:     this,
-                  });
-
-                  GUI.setModal(false);
-
-                  GUI.getPlugin('editing').emit('savedfeature', newFeatures);                 // called after saved
-                  GUI.getPlugin('editing').emit(`savedfeature_${this.layerId}`, newFeatures); // called after saved using layerId
-
-                  // In case of save of child, it means that child is updated so also parent
-                  if (this._isContentChild) {
-                    Workflow.Stack.parents.forEach(w => w?.getContext?.()?.service?.setUpdate?.(true, { force: true }));
-                  }
+                if (this._isContentChild) {
+                  inputs.relationFeatures = {
+                    newFeatures,
+                    originalFeatures: this._originalFeatures
+                  };
                 }
 
+                await GUI.getPlugin('editing').emit('saveform', { newFeatures, originalFeatures: this._originalFeatures });
+
+                newFeatures.forEach((f, i) => context.session.pushUpdate(this.layerId, f, this._originalFeatures[i]));
+
+                // check and handle if layer has relation 1:1
+                await _handleRelation1_1LayerFields({
+                  layerId:  this.layerId,
+                  features: newFeatures,
+                  fields,
+                  task:     this,
+                });
+
+                GUI.setModal(false);
+
+                GUI.getPlugin('editing').emit('savedfeature', newFeatures);                 // called after saved
+                GUI.getPlugin('editing').emit(`savedfeature_${this.layerId}`, newFeatures); // called after saved using layerId
+
+                // In case of save of child, it means that child is updated so also parent
+                if (this._isContentChild) {
+                  Workflow.Stack.parents.forEach(w => w?.getContext?.()?.service?.setUpdate?.(true, { force: true }));
+                }
+              
                 GUI.setLoadingContent(false);
                 GUI.disableContent(false);
                 

--- a/g3w-admin/editing/static/editing/js/actions/open-form.js
+++ b/g3w-admin/editing/static/editing/js/actions/open-form.js
@@ -356,15 +356,13 @@ export class OpenFormStep extends Step {
               // save features
               cbk: async (fields = []) => {
                 const service    = Workflow.Stack.current.getContext().service;
-                //Check if there are updates on the form fields or if the feature is new
-                const hasUpdates = !!service?.state?.fields?.some(f => f.update);
-                //Check if there are new features in the form (i.e., features that are not yet saved to the server)
-                const isNew      = !!this._originalFeatures?.some(f => f.isNew?.());
+                const hasUpdates = !!service?.state?.fields?.some(f => f.update);    // check for updates in form fields or if the feature is new
+                const isNew      = !!this._originalFeatures?.some(f => f.isNew?.()); // check for new features in form (i.e., features that are not yet saved to the server)
                 const newFeatures = [];
 
                 fields = this._multi ? fields.filter(f => null !== f.value) : fields;
-                
-                // skip when no fields or Avoid creating an "update" session change when nothing changed on an existing non-relation feature.
+
+                // skip when no fields or when nothing changed (on an existing non-relation feature).
                 if (0 === fields.length || (!isNew && !hasUpdates)) {
                   resolve(inputs);
                   return;
@@ -403,14 +401,14 @@ export class OpenFormStep extends Step {
                 GUI.getPlugin('editing').emit('savedfeature', newFeatures);                 // called after saved
                 GUI.getPlugin('editing').emit(`savedfeature_${this.layerId}`, newFeatures); // called after saved using layerId
 
-                // In case of save of child, it means that child is updated so also parent
+                // sync parent workflows when child is saved.
                 if (this._isContentChild) {
                   Workflow.Stack.parents.forEach(w => w?.getContext?.()?.service?.setUpdate?.(true, { force: true }));
                 }
               
                 GUI.setLoadingContent(false);
                 GUI.disableContent(false);
-                
+
                 //@TODO add field unique new value id not set
                 resolve(inputs);
               }


### PR DESCRIPTION
Project: https://v311.g3wsuite.it/en/map/g3w-suite-demo/qdjango/97/

Need to fix https://github.com/g3w-suite/g3w-admin/pull/1331/changes/448921a9ac5e948b9d423a5316102b3278b7912c because in case of create new relation , and this relation has no mandatory fields, or only mandatory pk field not editible and fill by server, the relaion afetr save is not added to relations of parent feature

If we try to add a new relation to _Green Building_


<img width="632" height="353" alt="Screenshot_20260807_120050" src="https://github.com/user-attachments/assets/2f05f0e8-16a8-416e-9e90-a44988f76c38" />


### Before


<img width="672" height="351" alt="Screenshot_20260807_120224" src="https://github.com/user-attachments/assets/f34110c5-372b-4e07-b1e6-9056b35e4107" />

<img width="682" height="969" alt="Screenshot_20260807_120256" src="https://github.com/user-attachments/assets/0592aefa-0377-48b8-a4f0-6f1ac60fb6bf" />

No new relation is add. Still 2 relations

<img width="682" height="501" alt="Screenshot_20260807_120324" src="https://github.com/user-attachments/assets/4b089a5e-89c0-4199-994e-8193a62b7e5b" />

### After

<img width="672" height="351" alt="Screenshot_20260807_120224" src="https://github.com/user-attachments/assets/f34110c5-372b-4e07-b1e6-9056b35e4107" />

<img width="682" height="969" alt="Screenshot_20260807_120256" src="https://github.com/user-attachments/assets/0592aefa-0377-48b8-a4f0-6f1ac60fb6bf" />

New relation is add

<img width="682" height="501" alt="Screenshot_20260807_120453" src="https://github.com/user-attachments/assets/5df29dd4-5bb0-449e-8c94-3f23bab6ddbb" />


