### PR TITLE
Fix edit feature from attribute table in case of vector layer and no geometry set

### DIFF
--- a/g3w-admin/editing/static/editing/js/index.js
+++ b/g3w-admin/editing/static/editing/js/index.js
@@ -525,7 +525,7 @@ new (class extends Plugin {
             // confirm step
             new (await import('./g3w-step.js')).Step({
               run(inputs) {
-                return new Promise(async (resolve, reject) => {
+                const promise = new Promise(async (resolve, reject) => {
                   const dialog = GUI.dialog({
                     message: inputs.message,
                     title:   `${_("plugins.editing.messages.commit_feature")}: "${inputs.layer.getName()}"`,
@@ -537,12 +537,13 @@ new (class extends Plugin {
                   });
                   if (inputs.features) {
                     (await import('./utils/setAndUnsetSelectedFeaturesStyle.js')).setAndUnsetSelectedFeaturesStyle({
-                      promise: promise(),
+                      promise,
                       inputs,
                       style: this.selectStyle,
                     });
                   }
-                })
+                });
+                return promise;
               },
             }
             ),

--- a/g3w-admin/editing/static/editing/js/utils/areCoordinatesEqual.js
+++ b/g3w-admin/editing/static/editing/js/utils/areCoordinatesEqual.js
@@ -12,7 +12,7 @@ export function areCoordinatesEqual({
 }) {
  //get geometry from feature
  const geometry = feature.getGeometry();
- const type     = geometry.getType();
+ const type     = geometry?.getType?.();
  const coords   = (c1, c2) => g3wsdk.core.geoutils.areCoordinatesEqual(c1, c2); // whether element have same coordinates
 
  switch (type) {

--- a/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
+++ b/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
@@ -10,7 +10,7 @@ import { setFeaturesSelectedStyle } from '../utils/setFeaturesSelectedStyle.js';
  * @param { Array }  inputs.features
  * @param { ol.style.Style } style
  */
-export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}) {
+export function setAndUnsetSelectedFeaturesStyle({ promise, inputs = {}, style } = {}) {
   
   /** @FIXME temporary add in order to fix issue on pending promise (but which issue ?) */
   const {
@@ -19,7 +19,7 @@ export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}
   } = inputs;
 
   // skip on invalid vector layer
-  if ('vector' !== layer.getType() || features.flat().some(f => !f?.getGeometry?.())) {
+  if ('vector' !== layer?.getType?.() || features.flat().some(f => !f?.getGeometry?.())) {
     return;
   }
 

--- a/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
+++ b/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
@@ -36,8 +36,9 @@ export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}
     }
   };
 
-  // check if layer is vector and features has geometry (case add part to a feature that has no geometry)
-  const is_vector = 'vector' === layer.getType() && features.every(f => f.getGeometry());
+  // check if layer is vector and features have geometry (case: add part to a feature that has no geometry)
+  const _features = features.flat();
+  const is_vector = 'vector' === layer.getType() && _features.every(f => f?.getGeometry?.());
 
   if (is_vector && Workflow.Stack.length) {
     setTimeout(() => selectOriginalStyleHandle());

--- a/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
+++ b/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
@@ -40,9 +40,5 @@ export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}
     }
   };
 
-  if (Workflow.Stack.length) {
-    setTimeout(() => setStyle());
-  } else {
-    setStyle();
-  }
+  setTimeout(setStyle);
 }

--- a/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
+++ b/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
@@ -1,15 +1,14 @@
 import { Workflow }                 from '../g3w-workflow.js';
-import { setFeaturesSelectedStyle } from '../utils/setFeaturesSelectedStyle.js';
+import { setFeaturesSelectedStyle } from './setFeaturesSelectedStyle.js';
 
 /**
- * ORIGINAL SOURCE: g3w-client-plugin-editing/workflows/tasks/editingtask.js@v3.7.1
- * 
- * Method that set selected style to current editing features and
- * reset original style when workflow (tool) is done.
+ * Set selected style to current editing features and reset original style when workflow (tool) is done.
  * 
  * @param promise
  * @param { Object } inputs
- * @param { ol.style.Style }  style
+ * @param { Object } inputs.layer
+ * @param { Array }  inputs.features
+ * @param { ol.style.Style } style
  */
 export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}) {
   
@@ -19,13 +18,18 @@ export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}
       features = [],
   } = inputs;
 
+  // skip on invalid vector layer
+  if ('vector' !== layer.getType() || features.flat().some(f => !f?.getGeometry?.())) {
+    return;
+  }
+
   /**
    * @TODO if coming from relation ( Workflow.Stack.length > 1 )
    *       no need setTimeout because we already it has selected style
    *       so original is the same selected. In case of current layer
    *       need to wait.
    */
-  const selectOriginalStyleHandle = async () => {
+  const setStyle = async () => {
     const originalStyle = setFeaturesSelectedStyle(features, style);
     try {
       await promise;
@@ -36,12 +40,9 @@ export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}
     }
   };
 
-  // check if layer is vector and features have geometry (case: add part to a feature that has no geometry)
-  const is_vector = 'vector' === layer.getType() && features.flat().every(f => f?.getGeometry?.());
-
-  if (is_vector && Workflow.Stack.length) {
-    setTimeout(() => selectOriginalStyleHandle());
-  } else if (is_vector) {
-    selectOriginalStyleHandle();
+  if (Workflow.Stack.length) {
+    setTimeout(() => setStyle());
+  } else {
+    setStyle();
   }
 }

--- a/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
+++ b/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
@@ -36,7 +36,8 @@ export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}
     }
   };
 
-  const is_vector = 'vector' === layer.getType();
+  // check if layer is vector and features has geometry (case add part to a feature that has no geometry)
+  const is_vector = 'vector' === layer.getType() && features.every(f => f.getGeometry());
 
   if (is_vector && Workflow.Stack.length) {
     setTimeout(() => selectOriginalStyleHandle());

--- a/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
+++ b/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
@@ -1,5 +1,5 @@
 import { Workflow }                 from '../g3w-workflow.js';
-import { setFeaturesSelectedStyle } from './setFeaturesSelectedStyle.js';
+import { setFeaturesSelectedStyle } from '../utils/setFeaturesSelectedStyle.js';
 
 /**
  * Set selected style to current editing features and reset original style when workflow (tool) is done.

--- a/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
+++ b/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
@@ -37,8 +37,7 @@ export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}
   };
 
   // check if layer is vector and features have geometry (case: add part to a feature that has no geometry)
-  const _features = features.flat();
-  const is_vector = 'vector' === layer.getType() && _features.every(f => f?.getGeometry?.());
+  const is_vector = 'vector' === layer.getType() && features.flat().every(f => f?.getGeometry?.());
 
   if (is_vector && Workflow.Stack.length) {
     setTimeout(() => selectOriginalStyleHandle());

--- a/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
+++ b/g3w-admin/editing/static/editing/js/utils/setAndUnsetSelectedFeaturesStyle.js
@@ -23,13 +23,8 @@ export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}
     return;
   }
 
-  /**
-   * @TODO if coming from relation ( Workflow.Stack.length > 1 )
-   *       no need setTimeout because we already it has selected style
-   *       so original is the same selected. In case of current layer
-   *       need to wait.
-   */
-  const setStyle = async () => {
+  // wait for DOM changes
+  setTimeout(async () => {
     const originalStyle = setFeaturesSelectedStyle(features, style);
     try {
       await promise;
@@ -38,7 +33,5 @@ export function setAndUnsetSelectedFeaturesStyle({ promise, inputs, style } = {}
     } finally {
       features.flat().forEach((f => f.setStyle(originalStyle)))
     }
-  };
-
-  setTimeout(setStyle);
+  });
 }


### PR DESCRIPTION
This pull request focuses on improving the robustness of geometry-related utility functions by adding defensive checks. The main changes ensure that operations are only performed on features and layers with valid geometries, which helps prevent runtime errors in edge cases.

**Geometry and type safety improvements:**

* In `areCoordinatesEqual.js`, added optional chaining to safely access the geometry type, preventing errors if the geometry is missing or undefined.
* In `setAndUnsetSelectedFeaturesStyle.js`, enhanced the vector layer check to ensure all features have geometries before applying styles, addressing cases where features may lack geometry (such as when adding a part to a feature without geometry).

Project: https://v311.g3wsuite.it/en/map/demo-311/qdjango/276/

Steps:

1. Open attribute table of multigeomPoly
2. Click pencil icon on a row that has triangle icon (item has no geometry)
<img width="682" height="65" alt="Screenshot_20260810_153427" src="https://github.com/user-attachments/assets/d397dea3-d2e8-47f9-a100-657f8e10a9aa" />


### Before

After click on pencil icon, load feature and show form for change attribute table

<img width="1003" height="1017" alt="Screenshot_20260810_153736" src="https://github.com/user-attachments/assets/4b434802-789c-4180-b0b4-699f85dace31" />

We don't want change attribute but add gemetry. So we close open form, and click on add Part tool

<img width="786" height="433" alt="Screenshot_20260810_153939" src="https://github.com/user-attachments/assets/0fdc5f8d-b8ce-4974-80f3-b60514a4ebde" />

One click we get first javascript error on developer console

<img width="822" height="144" alt="Screenshot_20260810_154043" src="https://github.com/user-attachments/assets/7fdd667b-d413-4040-9f4f-9b8089784127" />

We draw a geometry and try to save changes. We get a javascript error


<img width="1920" height="457" alt="Screenshot_20260810_154145" src="https://github.com/user-attachments/assets/163568bf-3ad9-4b98-92ed-c8b3a97aca39" />


###After


<img width="937" height="647" alt="Screenshot_20260810_154250" src="https://github.com/user-attachments/assets/61d5bf55-b404-49ba-8bb8-b8371b4bdced" />

and then if we open attribute table, the row of the feature has not more triangle icon (item has no geometry)

<img width="937" height="114" alt="Screenshot_20260810_154351" src="https://github.com/user-attachments/assets/8fe55a5e-fccb-4c8e-ab58-8b21cc03ee31" />
